### PR TITLE
Support az:// scheme

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -103,7 +103,7 @@ jobs:
         aarch64_cross_compile: 1
 
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: 9edb1b8e590cc086563301d735cae4b6e732d2d2
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@v0.9.1
+    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@60ddc316ca0c1585f14d55aa73f9db59d8fc05d1
     with:
       duckdb_version: v0.9.1
       extension_name: azure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,12 @@ add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 
-find_package(azure-identity-cpp CONFIG REQUIRED)
-find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+find_package(azure-identity-cpp CONFIG)
+find_package(azure-storage-blobs-cpp CONFIG)
+
+if(NOT ${azure-identity-cpp_FOUND} OR NOT ${azure-storage-blobs-cpp_FOUND})
+  message(FATAL_ERROR "Azure SDK not found, did you set up vcpkg correctly?")
+endif()
 
 # Static lib
 target_link_libraries(${EXTENSION_NAME} Azure::azure-identity

--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -30,6 +30,7 @@ struct AzureAuthentication {
 
 struct AzureParsedUrl {
 	string container;
+	string prefix;
 	string path;
 };
 

--- a/test/sql/azure.test
+++ b/test/sql/azure.test
@@ -10,8 +10,10 @@ require parquet
 require-env AZURE_STORAGE_CONNECTION_STRING
 
 # We need a connection string to do requests
+foreach prefix azure:// az://
+
 statement error
-SELECT sum(l_orderkey) FROM 'azure://testing-private/l.parquet';
+SELECT sum(l_orderkey) FROM '${prefix}testing-private/l.parquet';
 ----
 Invalid Input Error: No valid Azure credentials found
 
@@ -21,17 +23,23 @@ SET azure_storage_connection_string = '${AZURE_STORAGE_CONNECTION_STRING}';
 
 # Read a column from a parquet file
 query I
-SELECT sum(l_orderkey) FROM 'azure://testing-private/l.parquet';
+SELECT sum(l_orderkey) FROM '${prefix}testing-private/l.parquet';
 ----
 1802759573
 
 # Read from a csv file with no header
 query I
-SELECT count(*) FROM 'azure://testing-private/lineitem.csv';
+SELECT count(*) FROM '${prefix}testing-private/lineitem.csv';
 ----
 60175
 
 query I
-SELECT count(*) FROM 'azure://testing-private/l.csv';
+SELECT count(*) FROM '${prefix}testing-private/l.csv';
 ----
 60175
+
+# Unset the connection string var
+statement ok
+SET azure_storage_connection_string = '';
+
+endloop

--- a/test/sql/azure_glob.test
+++ b/test/sql/azure_glob.test
@@ -59,3 +59,19 @@ query I
 SELECT * from GLOB("azure://testing-public/lineitem.*") order by file;
 ----
 azure://testing-public/lineitem.csv
+
+# Testing private blobs with az:// prefix
+query I
+SELECT * from GLOB("az://testing-private/*.*") order by file;
+----
+az://testing-private/l.csv
+az://testing-private/l.parquet
+az://testing-private/lineitem.csv
+
+# Testing public blobs with az:// prefix
+query I
+SELECT * from GLOB("az://testing-public/*.*") order by file;
+----
+az://testing-public/l.csv
+az://testing-public/l.parquet
+az://testing-public/lineitem.csv


### PR DESCRIPTION
This PR introduces the `az://` scheme and provides additional testing.
Additionally, it includes a CMake message for when the `azure-identity-cpp` and `azure-storage-blobs-cpp` packages cannot be found.