### PR TITLE
make buffer size, transfer size and concurrency configurable

### DIFF
--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -28,6 +28,12 @@ struct AzureAuthentication {
 	string endpoint;
 };
 
+struct AzureReadOptions {
+	int32_t transfer_concurrency = 5;
+	int64_t transfer_chunk_size = 1 * 1024 * 1024;
+	idx_t buffer_size = 1 * 1024 * 1024;
+};
+
 struct AzureParsedUrl {
 	string container;
 	string prefix;
@@ -47,7 +53,7 @@ protected:
 class AzureStorageFileHandle : public FileHandle {
 public:
 	AzureStorageFileHandle(FileSystem &fs, string path, uint8_t flags, AzureAuthentication &auth,
-	                       AzureParsedUrl parsed_url);
+	                       const AzureReadOptions &read_options, AzureParsedUrl parsed_url);
 	~AzureStorageFileHandle() override = default;
 
 public:
@@ -67,10 +73,12 @@ public:
 
 	// Read buffer
 	duckdb::unique_ptr<data_t[]> read_buffer;
-	constexpr static idx_t READ_BUFFER_LEN = 1000000;
 
 	// Azure Blob Client
 	BlobClientWrapper blob_client;
+
+	AzureReadOptions read_options;
+
 };
 
 class AzureStorageFileSystem : public FileSystem {


### PR DESCRIPTION
The read buffer size as well as the transfer chunk size and transfer concurrency options provided to the Azure Storage client have a large impact on both the duration of queries and number of transactions done against the Azure Storage Account. This PR makes these values configurable so that users can tune these settings to balance performance and transaction costs.

The following shows the impact on the duration of a query against a 1.9 GiB gzipped json lines blob:

azure_read_transfer_concurrency = 5 / azure_read_transfer_chunk_size = 1 MiB / azure_read_buffer_size = 1 MiB
69842.0027 ms

azure_read_transfer_concurrency = 1 / azure_read_transfer_chunk_size = 1 MiB / azure_read_buffer_size = 1 MiB
64520.8366 ms

azure_read_transfer_concurrency = 4 / azure_read_transfer_chunk_size = 32 MiB / azure_read_buffer_size = 128 MiB
46287.7139 ms

azure_read_transfer_concurrency = 16 / azure_read_transfer_chunk_size = 8 MiB / azure_read_buffer_size = 128 MiB
35221.4137 ms

azure_read_transfer_concurrency = 16 / azure_read_transfer_chunk_size = 16 MiB / azure_read_buffer_size = 256 MiB
29436.0231 ms

The number of transactions required to do the query will be approximately: BlobSize / azure_read_transfer_chunk_size

In this PR I chose defaults for these values as follows:
- I chose 5 for azure_read_transfer_concurrency because that seems to be the default in the Azure SDK.
- I chose 1 MiB for azure_read_transfer_chunk_size and azure_read_buffer_size because the current buffer size is 1 MB.  Actually, I just realized that the old buffer size was 1 MB and I changed it to 1 MiB.  I can switch that back if desired.