### PR TITLE
Add support for secrets

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -22,12 +22,7 @@ jobs:
           - arch: 'linux_amd64_gcc4'
             container: 'quay.io/pypa/manylinux2014_x86_64'
             vcpkg_triplet: 'x64-linux'
-          - arch: 'linux_amd64'
-            container: 'ubuntu:18.04'
-            vcpkg_triplet: 'x64-linux'
-          - arch: 'linux_arm64'
-            container: 'ubuntu:18.04'
-            vcpkg_triplet: 'arm64-linux'
+
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       GEN: Ninja
@@ -105,7 +100,7 @@ jobs:
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1
       with:
-        vcpkgGitCommitId: 9edb1b8e590cc086563301d735cae4b6e732d2d2
+        vcpkgGitCommitId: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
 
     # Build extension
     - name: Build extension

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -16,12 +16,10 @@ jobs:
       matrix:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: [ '<submodule_version>' ]
-        arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
+        arch: ['linux_amd64_gcc4']
         vcpkg_version: [ '2023.04.15' ]
-        include:
-          - arch: 'linux_amd64_gcc4'
-            container: 'quay.io/pypa/manylinux2014_x86_64'
-            vcpkg_triplet: 'x64-linux'
+        container: ['quay.io/pypa/manylinux2014_x86_64']
+        vcpkg_triplet: ['x64-linux']
 
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -21,9 +21,6 @@ jobs:
           - vcpkg_triplet: 'x64-osx'
             osx_build_arch: 'x86_64'
             duckdb_arch: 'osx_amd64'
-          - vcpkg_triplet: 'arm64-osx'
-            osx_build_arch: 'arm64'
-            duckdb_arch: 'osx_arm64'
 
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
@@ -54,7 +51,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 9edb1b8e590cc086563301d735cae4b6e732d2d2
+          vcpkgGitCommitId: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
 
       - name: Build extension
         shell: bash

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -13,14 +13,11 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # Add commits/tags to build against other DuckDB versions
         duckdb_version: [ '<submodule_version>' ]
         vcpkg_version: [ '2023.04.15' ]
-        vcpkg_triplet: [ 'x64-osx', 'arm64-osx' ]
-        include:
-          - vcpkg_triplet: 'x64-osx'
-            osx_build_arch: 'x86_64'
-            duckdb_arch: 'osx_amd64'
+        vcpkg_triplet: [ 'x64-osx']
+        osx_build_arch: ['x86_64']
+        duckdb_arch: ['osx_amd64']
 
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,11 +14,10 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@v0.9.2
+    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@a491470b039c54fe2f0adfe1d161b14c7fe64642
     with:
-      duckdb_version: v0.9.2
       extension_name: azure
-      vcpkg_commit: 9edb1b8e590cc086563301d735cae4b6e732d2d2 # TODO: remove pinned vcpkg commit when updating duckdb version
+      duckdb_version: a491470b03
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
@@ -26,6 +25,6 @@ jobs:
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v0.9.2
       extension_name: azure
+      duckdb_version: a491470b03
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,6 +17,7 @@ jobs:
     uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@a491470b039c54fe2f0adfe1d161b14c7fe64642
     with:
       extension_name: azure
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads' # Can't really work in wasm sandbox
       duckdb_version: a491470b03
 
   duckdb-stable-deploy:
@@ -26,5 +27,6 @@ jobs:
     secrets: inherit
     with:
       extension_name: azure
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
       duckdb_version: a491470b03
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(src/include)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(EXTENSION_SOURCES src/azure_extension.cpp)
+set(EXTENSION_SOURCES src/azure_extension.cpp src/azure_secret.cpp)
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 
 set(PARAMETERS "-warnings")

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -45,7 +45,7 @@ CreateCredentialChainFromSetting(const string &credential_chain) {
 	return result;
 }
 
-static AzureAuthentication ParseAzureAuthSettings(FileOpener *opener, const string& path) {
+static AzureAuthentication ParseAzureAuthSettings(FileOpener *opener, const string &path) {
 	AzureAuthentication auth;
 
 	// Lookup Secret
@@ -55,7 +55,7 @@ static AzureAuthentication ParseAzureAuthSettings(FileOpener *opener, const stri
 		auto secret_lookup = context->db->config.secret_manager->LookupSecret(transaction, path, "azure");
 		if (secret_lookup.HasMatch()) {
 			const auto &secret = secret_lookup.GetSecret();
-			auth.secret = &dynamic_cast<const KeyValueSecret&>(secret);
+			auth.secret = &dynamic_cast<const KeyValueSecret &>(secret);
 		}
 	}
 
@@ -95,10 +95,10 @@ static Azure::Storage::Blobs::BlobContainerClient GetContainerClient(AzureAuthen
 	// Firstly, try to use the auth from the secret
 	if (auth.secret) {
 		// If connection string, we're done heres
-		auto connection_string_value =  auth.secret->TryGetValue("connection_string");
+		auto connection_string_value = auth.secret->TryGetValue("connection_string");
 		if (!connection_string_value.IsNull()) {
-			return Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(connection_string_value.ToString(),
-				                                                                              url.container);
+			return Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(
+			    connection_string_value.ToString(), url.container);
 		}
 
 		// Account_name can be used both for unauthenticated
@@ -177,7 +177,9 @@ AzureStorageFileHandle::AzureStorageFileHandle(FileSystem &fs, string path_p, ui
 		throw IOException("AzureStorageFileSystem open file '" + path + "' failed with code'" + e.ErrorCode +
 		                  "',Reason Phrase: '" + e.ReasonPhrase + "', Message: '" + e.Message + "'");
 	} catch (std::exception &e) {
-		throw IOException("AzureStorageFileSystem could not open file: '%s', unknown error occured, this could mean the credentials used were wrong. Original error message: '%s' ", path, e.what());
+		throw IOException("AzureStorageFileSystem could not open file: '%s', unknown error occured, this could mean "
+		                  "the credentials used were wrong. Original error message: '%s' ",
+		                  path, e.what());
 	}
 
 	if (flags & FileFlags::FILE_FLAGS_READ) {

--- a/src/azure_secret.cpp
+++ b/src/azure_secret.cpp
@@ -1,0 +1,154 @@
+#include "azure_secret.hpp"
+#include "duckdb/main/extension_util.hpp"
+#include <azure/identity/azure_cli_credential.hpp>
+#include <azure/identity/chained_token_credential.hpp>
+#include <azure/identity/default_azure_credential.hpp>
+#include <azure/identity/environment_credential.hpp>
+#include <azure/identity/managed_identity_credential.hpp>
+#include <azure/storage/blobs.hpp>
+
+namespace duckdb {
+
+// TODO DEDUP
+static Azure::Identity::ChainedTokenCredential::Sources
+CreateCredentialChainFromSetting(const string &credential_chain) {
+	auto chain_list = StringUtil::Split(credential_chain, ';');
+	Azure::Identity::ChainedTokenCredential::Sources result;
+
+	for (const auto &item : chain_list) {
+		if (item == "cli") {
+			result.push_back(std::make_shared<Azure::Identity::AzureCliCredential>());
+		} else if (item == "managed_identity") {
+			result.push_back(std::make_shared<Azure::Identity::ManagedIdentityCredential>());
+		} else if (item == "env") {
+			result.push_back(std::make_shared<Azure::Identity::EnvironmentCredential>());
+		} else if (item == "default") {
+			result.push_back(std::make_shared<Azure::Identity::DefaultAzureCredential>());
+		} else if (item != "none") {
+			throw InvalidInputException("Unknown credential provider found: " + item);
+		}
+	}
+
+	return result;
+}
+
+static unique_ptr<BaseSecret> CreateAzureSecretFromConnectionString(ClientContext &context, CreateSecretInput &input) {
+	string connection_string;
+
+	for (const auto &named_param : input.named_parameters) {
+		if (named_param.first == "connection_string") {
+			connection_string = named_param.second.ToString();
+		} else {
+			throw InternalException("Invalid parameter passed to CreateAzureSecretFromConnectionString: " +
+			                        named_param.first);
+		}
+	}
+
+	// Set scope to user provided scope or the default
+	auto scope = input.scope;
+	if (scope.empty()) {
+		scope.push_back("azure://");
+		scope.push_back("az://");
+	}
+
+	auto secret = make_uniq<AzureSecret>(scope, input.type, input.provider, input.name);
+	secret->SetConnectionString(connection_string);
+	return secret;
+}
+
+static unique_ptr<BaseSecret> CreateAzureSecretFromCredentialChain(ClientContext &context, CreateSecretInput &input) {
+	string credential_chain;
+	string account_name;
+	string azure_endpoint;
+	string token_string;
+	string token_expires_on;
+	int token_validity_minutes = -1;
+
+	for (const auto &named_param : input.named_parameters) {
+		if (named_param.first == "credential_chain") {
+			credential_chain = named_param.second.ToString();
+		} else if (named_param.first == "account_name") {
+			account_name = named_param.second.ToString();
+		} else if (named_param.first == "azure_endpoint") {
+			azure_endpoint = named_param.second.ToString();
+		} else if (named_param.first == "token_validity_minutes") {
+			if (!named_param.second.ToString().empty()) {
+				token_validity_minutes = Value(named_param.second.ToString()).DefaultCastAs(LogicalType::INTEGER).GetValue<int>();
+			}
+		} else {
+			throw InternalException("Invalid parameter passed to CreateAzureSecretFromCredentialChain: " +
+			                        named_param.first);
+		}
+	}
+
+	// TODO: unclear if this works
+	if (token_validity_minutes == -1) {
+		token_validity_minutes = 60 * 24 * 30; // 30 Days TODO: make global option
+	}
+
+	// Build credential chain, from last to first
+	Azure::Identity::ChainedTokenCredential::Sources chain;
+	if (!credential_chain.empty()) {
+		chain = CreateCredentialChainFromSetting(credential_chain);
+	} else {
+		chain = CreateCredentialChainFromSetting("default");
+	}
+
+	if (!chain.empty()) {
+		// A set of credentials providers was passed, construct a token from it
+		auto chainedTokenCredential = std::make_shared<Azure::Identity::ChainedTokenCredential>(chain);
+		Azure::Core::Credentials::TokenRequestContext token_request_context;
+		token_request_context.Scopes = {"https://storage.azure.com/.default"};
+		token_request_context.MinimumExpiration = std::chrono::minutes(1);
+		Azure::Core::Context azure_context;
+		auto token = chainedTokenCredential->GetToken(token_request_context, azure_context);
+		token_string = token.Token;
+		token_expires_on = token.ExpiresOn.ToString(Azure::DateTime::DateFormat::Rfc3339);
+	} else if (!account_name.empty()) {
+		// TODO unauthenticated path should be implemented: this allows specifying the other params (account name/endpoint)
+		// 		per scope, but without needing a valid token.
+		throw NotImplementedException("Unauth secrets are weird but useful?");
+	} else {
+		throw InvalidInputException(
+		    "No valid Azure credentials found, use either the azure_connection_string or azure_account_name");
+	}
+
+	// Set scope to user provided scope or the default
+	auto scope = input.scope;
+	if (scope.empty()) {
+		scope.push_back("azure://");
+		scope.push_back("az://");
+	}
+
+	auto secret = make_uniq<AzureSecret>(scope, input.type, input.provider, input.name);
+	secret->SetCredentialChainToken(credential_chain, account_name, token_string, token_expires_on, azure_endpoint);
+	return secret;
+}
+
+void CreateAzureSecretFunctions::Register(DatabaseInstance &instance) {
+	string type = "azure";
+
+	// Register the new type
+	SecretType secret_type;
+	secret_type.name = type;
+	secret_type.deserializer = BaseKeyValueSecret::Deserialize<AzureSecret>;
+	secret_type.default_provider = "connection_string";
+	ExtensionUtil::RegisterSecretType(instance, secret_type);
+
+	// Register the connection string secret provider
+	CreateSecretFunction connection_string_function = {type, "connection_string", CreateAzureSecretFromConnectionString};
+	connection_string_function.named_parameters["connection_string"] = LogicalType::VARCHAR;
+	ExtensionUtil::RegisterFunction(instance, connection_string_function);
+
+	// Register the credential_chain secret provider
+	CreateSecretFunction cred_chain_function = {type, "credential_chain", CreateAzureSecretFromCredentialChain};
+	cred_chain_function.named_parameters["credential_chain"] = LogicalType::VARCHAR;
+	cred_chain_function.named_parameters["account_name"] = LogicalType::VARCHAR;
+	cred_chain_function.named_parameters["azure_endpoint"] = LogicalType::VARCHAR;
+	cred_chain_function.named_parameters["token_validity_minutes"] = LogicalType::VARCHAR;
+	ExtensionUtil::RegisterFunction(instance, cred_chain_function);
+
+
+}
+
+} // namespace duckdb

--- a/src/azure_secret.cpp
+++ b/src/azure_secret.cpp
@@ -9,120 +9,68 @@
 
 namespace duckdb {
 
-// TODO DEDUP
-static Azure::Identity::ChainedTokenCredential::Sources
-CreateCredentialChainFromSetting(const string &credential_chain) {
-	auto chain_list = StringUtil::Split(credential_chain, ';');
-	Azure::Identity::ChainedTokenCredential::Sources result;
-
-	for (const auto &item : chain_list) {
-		if (item == "cli") {
-			result.push_back(std::make_shared<Azure::Identity::AzureCliCredential>());
-		} else if (item == "managed_identity") {
-			result.push_back(std::make_shared<Azure::Identity::ManagedIdentityCredential>());
-		} else if (item == "env") {
-			result.push_back(std::make_shared<Azure::Identity::EnvironmentCredential>());
-		} else if (item == "default") {
-			result.push_back(std::make_shared<Azure::Identity::DefaultAzureCredential>());
-		} else if (item != "none") {
-			throw InvalidInputException("Unknown credential provider found: " + item);
-		}
+static string TryGetStringParam(CreateSecretInput &input, const string &param_name) {
+	auto param_lookup = input.options.find(param_name);
+	if (param_lookup != input.options.end()) {
+		return param_lookup->second.ToString();
+	} else {
+		return "";
 	}
-
-	return result;
 }
 
-static unique_ptr<BaseSecret> CreateAzureSecretFromConnectionString(ClientContext &context, CreateSecretInput &input) {
-	string connection_string;
+static unique_ptr<BaseSecret> CreateAzureSecretFromConfig(ClientContext &context, CreateSecretInput &input) {
+	string connection_string = TryGetStringParam(input, "connection_string");
+	string account_name = TryGetStringParam(input, "account_name");
 
-	for (const auto &named_param : input.named_parameters) {
-		if (named_param.first == "connection_string") {
-			connection_string = named_param.second.ToString();
-		} else {
-			throw InternalException("Invalid parameter passed to CreateAzureSecretFromConnectionString: " +
-			                        named_param.first);
-		}
-	}
-
-	// Set scope to user provided scope or the default
 	auto scope = input.scope;
 	if (scope.empty()) {
 		scope.push_back("azure://");
 		scope.push_back("az://");
 	}
 
-	auto secret = make_uniq<AzureSecret>(scope, input.type, input.provider, input.name);
-	secret->SetConnectionString(connection_string);
-	return secret;
+	auto result = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+
+	//! Add connection string
+	if (!connection_string.empty()) {
+		result->secret_map["connection_string"] = connection_string;
+	}
+
+	// Add account_id
+	if (!account_name.empty()) {
+		result->secret_map["account_name"] = account_name;
+	}
+
+	//! Connection string may hold sensitive data: it should be redacted
+	result->redact_keys.insert("connection_string");
+
+	return std::move(result);
 }
 
 static unique_ptr<BaseSecret> CreateAzureSecretFromCredentialChain(ClientContext &context, CreateSecretInput &input) {
-	string credential_chain;
-	string account_name;
-	string azure_endpoint;
-	string token_string;
-	string token_expires_on;
-	int token_validity_minutes = -1;
+	string chain = TryGetStringParam(input, "chain");
+	string account_name = TryGetStringParam(input, "account_name");
+	string azure_endpoint = TryGetStringParam(input, "azure_endpoint");
 
-	for (const auto &named_param : input.named_parameters) {
-		if (named_param.first == "credential_chain") {
-			credential_chain = named_param.second.ToString();
-		} else if (named_param.first == "account_name") {
-			account_name = named_param.second.ToString();
-		} else if (named_param.first == "azure_endpoint") {
-			azure_endpoint = named_param.second.ToString();
-		} else if (named_param.first == "token_validity_minutes") {
-			if (!named_param.second.ToString().empty()) {
-				token_validity_minutes = Value(named_param.second.ToString()).DefaultCastAs(LogicalType::INTEGER).GetValue<int>();
-			}
-		} else {
-			throw InternalException("Invalid parameter passed to CreateAzureSecretFromCredentialChain: " +
-			                        named_param.first);
-		}
-	}
-
-	// TODO: unclear if this works
-	if (token_validity_minutes == -1) {
-		token_validity_minutes = 60 * 24 * 30; // 30 Days TODO: make global option
-	}
-
-	// Build credential chain, from last to first
-	Azure::Identity::ChainedTokenCredential::Sources chain;
-	if (!credential_chain.empty()) {
-		chain = CreateCredentialChainFromSetting(credential_chain);
-	} else {
-		chain = CreateCredentialChainFromSetting("default");
-	}
-
-	if (!chain.empty()) {
-		// A set of credentials providers was passed, construct a token from it
-		auto chainedTokenCredential = std::make_shared<Azure::Identity::ChainedTokenCredential>(chain);
-		Azure::Core::Credentials::TokenRequestContext token_request_context;
-		token_request_context.Scopes = {"https://storage.azure.com/.default"};
-		token_request_context.MinimumExpiration = std::chrono::minutes(1);
-		Azure::Core::Context azure_context;
-		auto token = chainedTokenCredential->GetToken(token_request_context, azure_context);
-		token_string = token.Token;
-		token_expires_on = token.ExpiresOn.ToString(Azure::DateTime::DateFormat::Rfc3339);
-	} else if (!account_name.empty()) {
-		// TODO unauthenticated path should be implemented: this allows specifying the other params (account name/endpoint)
-		// 		per scope, but without needing a valid token.
-		throw NotImplementedException("Unauth secrets are weird but useful?");
-	} else {
-		throw InvalidInputException(
-		    "No valid Azure credentials found, use either the azure_connection_string or azure_account_name");
-	}
-
-	// Set scope to user provided scope or the default
 	auto scope = input.scope;
 	if (scope.empty()) {
 		scope.push_back("azure://");
 		scope.push_back("az://");
 	}
 
-	auto secret = make_uniq<AzureSecret>(scope, input.type, input.provider, input.name);
-	secret->SetCredentialChainToken(credential_chain, account_name, token_string, token_expires_on, azure_endpoint);
-	return secret;
+	auto result = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+
+	// Add config to kv secret
+	if (input.options.find("chain") != input.options.end()) {
+		result->secret_map["chain"] = TryGetStringParam(input, "chain");
+	}
+	if (input.options.find("account_name") != input.options.end()) {
+		result->secret_map["account_name"] = TryGetStringParam(input, "account_name");
+	}
+	if (input.options.find("azure_endpoint") != input.options.end()) {
+		result->secret_map["azure_endpoint"] = TryGetStringParam(input, "azure_endpoint");
+	}
+
+	return std::move(result);
 }
 
 void CreateAzureSecretFunctions::Register(DatabaseInstance &instance) {
@@ -131,21 +79,21 @@ void CreateAzureSecretFunctions::Register(DatabaseInstance &instance) {
 	// Register the new type
 	SecretType secret_type;
 	secret_type.name = type;
-	secret_type.deserializer = BaseKeyValueSecret::Deserialize<AzureSecret>;
-	secret_type.default_provider = "connection_string";
+	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	secret_type.default_provider = "config";
 	ExtensionUtil::RegisterSecretType(instance, secret_type);
 
 	// Register the connection string secret provider
-	CreateSecretFunction connection_string_function = {type, "connection_string", CreateAzureSecretFromConnectionString};
+	CreateSecretFunction connection_string_function = {type, "config", CreateAzureSecretFromConfig};
 	connection_string_function.named_parameters["connection_string"] = LogicalType::VARCHAR;
+	connection_string_function.named_parameters["account_name"] = LogicalType::VARCHAR;
 	ExtensionUtil::RegisterFunction(instance, connection_string_function);
 
 	// Register the credential_chain secret provider
 	CreateSecretFunction cred_chain_function = {type, "credential_chain", CreateAzureSecretFromCredentialChain};
-	cred_chain_function.named_parameters["credential_chain"] = LogicalType::VARCHAR;
+	cred_chain_function.named_parameters["chain"] = LogicalType::VARCHAR;
 	cred_chain_function.named_parameters["account_name"] = LogicalType::VARCHAR;
 	cred_chain_function.named_parameters["azure_endpoint"] = LogicalType::VARCHAR;
-	cred_chain_function.named_parameters["token_validity_minutes"] = LogicalType::VARCHAR;
 	ExtensionUtil::RegisterFunction(instance, cred_chain_function);
 
 

--- a/src/azure_secret.cpp
+++ b/src/azure_secret.cpp
@@ -95,8 +95,6 @@ void CreateAzureSecretFunctions::Register(DatabaseInstance &instance) {
 	cred_chain_function.named_parameters["account_name"] = LogicalType::VARCHAR;
 	cred_chain_function.named_parameters["azure_endpoint"] = LogicalType::VARCHAR;
 	ExtensionUtil::RegisterFunction(instance, cred_chain_function);
-
-
 }
 
 } // namespace duckdb

--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -88,6 +88,8 @@ public:
 
 class AzureStorageFileSystem : public FileSystem {
 public:
+	~AzureStorageFileSystem();
+
 	duckdb::unique_ptr<FileHandle> OpenFile(const string &path, uint8_t flags, FileLockType lock = DEFAULT_LOCK,
 	                                        FileCompressionType compression = DEFAULT_COMPRESSION,
 	                                        FileOpener *opener = nullptr) final;

--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -12,6 +12,7 @@ class BlobClient;
 
 namespace duckdb {
 class AzureSecret;
+class KeyValueSecret;
 
 class AzureExtension : public Extension {
 public:
@@ -21,7 +22,7 @@ public:
 
 struct AzureAuthentication {
 	//! Main Auth method: through secret
-	shared_ptr<const AzureSecret> secret;
+	optional_ptr <const KeyValueSecret> secret;
 
 	//! Auth method #1: setting the connection string
 	string connection_string;

--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -11,6 +11,7 @@ class BlobClient;
 } // namespace Azure
 
 namespace duckdb {
+class AzureSecret;
 
 class AzureExtension : public Extension {
 public:
@@ -19,6 +20,9 @@ public:
 };
 
 struct AzureAuthentication {
+	//! Main Auth method: through secret
+	shared_ptr<const AzureSecret> secret;
+
 	//! Auth method #1: setting the connection string
 	string connection_string;
 

--- a/src/include/azure_extension.hpp
+++ b/src/include/azure_extension.hpp
@@ -22,7 +22,7 @@ public:
 
 struct AzureAuthentication {
 	//! Main Auth method: through secret
-	optional_ptr <const KeyValueSecret> secret;
+	optional_ptr<const KeyValueSecret> secret;
 
 	//! Auth method #1: setting the connection string
 	string connection_string;

--- a/src/include/azure_secret.hpp
+++ b/src/include/azure_secret.hpp
@@ -2,6 +2,7 @@
 
 #include "azure_extension.hpp"
 #include "duckdb.hpp"
+#include <duckdb/main/secret/secret.hpp>
 
 #include <azure/identity/azure_cli_credential.hpp>
 #include <azure/identity/chained_token_credential.hpp>
@@ -13,73 +14,6 @@
 namespace duckdb {
 struct CreateSecretInput;
 class CreateSecretFunction;
-
-// The Azure SDK doesn't appear to have a TokenCredential which is just a raw token: we need that because this
-// allows our secrets to be serializable
-class RawTokenCredential : public Azure::Core::Credentials::TokenCredential {
-public:
-	RawTokenCredential(const string& token_name) : Azure::Core::Credentials::TokenCredential(token_name) {
-	}
-	Azure::Core::Credentials::AccessToken GetToken(
-	    Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
-	    Azure::Core::Context const& context) const override {
-	    return raw_token;
-	};
-	Azure::Core::Credentials::AccessToken raw_token;
-};
-
-class AzureSecret : public BaseKeyValueSecret {
-public:
-	static case_insensitive_set_t GetRedactionSet() {
-		return {"connection_string"};
-	}
-	AzureSecret(BaseKeyValueSecret &secret) : BaseKeyValueSecret(secret) {
-		redact_keys = GetRedactionSet();
-	};
-	AzureSecret(BaseSecret &secret) : BaseKeyValueSecret(secret) {
-		redact_keys = GetRedactionSet();
-	};
-	AzureSecret(vector<string> &prefix_paths_p, string &type, string &provider, string &name)
-	    : BaseKeyValueSecret(prefix_paths_p, type, provider, name) {
-		redact_keys = GetRedactionSet();
-	};
-
-	unique_ptr<Azure::Storage::Blobs::BlobContainerClient> GetContainerClient(AzureParsedUrl &url) const {
-		if (secret_map.find("connection_string") != secret_map.end()) {
-			return make_uniq<Azure::Storage::Blobs::BlobContainerClient>(
-			    Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(secret_map.at("connection_string"), url.container));
-		}
-
-		if (secret_map.find("credential_chain") != secret_map.end()) {
-			auto raw_token_credential = make_shared<RawTokenCredential>(name);
-			raw_token_credential->raw_token.Token = secret_map.at("current_token");
-			raw_token_credential->raw_token.ExpiresOn = Azure::DateTime::Parse(secret_map.at("expires_on"), Azure::DateTime::DateFormat::Rfc3339);
-
-			string azure_endpoint = secret_map.at("endpoint");
-			if (azure_endpoint.empty()) {
-				azure_endpoint = "blob.core.windows.net";
-			}
-
-			auto accountURL = "https://" + secret_map.at("account_name") + "." + azure_endpoint;
-			Azure::Storage::Blobs::BlobServiceClient blob_service_client(accountURL, raw_token_credential);
-			return make_uniq<Azure::Storage::Blobs::BlobContainerClient>(blob_service_client.GetBlobContainerClient(url.container));
-		}
-
-		return nullptr;
-	}
-
-	void SetConnectionString(const string& connection_string) {
-		secret_map["connection_string"] = connection_string;
-	}
-
-	void SetCredentialChainToken(const string& credential_chain, const string& account_name, const string& current_token, const string& expires_on, const string& endpoint = "") {
-		secret_map["credential_chain"] = credential_chain;
-		secret_map["account_name"] = account_name;
-		secret_map["current_token"] = current_token;
-		secret_map["expires_on"] = expires_on;
-		secret_map["endpoint"] = endpoint;
-	}
-};
 
 struct CreateAzureSecretFunctions {
 public:

--- a/src/include/azure_secret.hpp
+++ b/src/include/azure_secret.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "azure_extension.hpp"
+#include "duckdb.hpp"
+
+#include <azure/identity/azure_cli_credential.hpp>
+#include <azure/identity/chained_token_credential.hpp>
+#include <azure/identity/default_azure_credential.hpp>
+#include <azure/identity/environment_credential.hpp>
+#include <azure/identity/managed_identity_credential.hpp>
+#include <azure/storage/blobs.hpp>
+
+namespace duckdb {
+struct CreateSecretInput;
+class CreateSecretFunction;
+
+// The Azure SDK doesn't appear to have a TokenCredential which is just a raw token: we need that because this
+// allows our secrets to be serializable
+class RawTokenCredential : public Azure::Core::Credentials::TokenCredential {
+public:
+	RawTokenCredential(const string& token_name) : Azure::Core::Credentials::TokenCredential(token_name) {
+	}
+	Azure::Core::Credentials::AccessToken GetToken(
+	    Azure::Core::Credentials::TokenRequestContext const& tokenRequestContext,
+	    Azure::Core::Context const& context) const override {
+	    return raw_token;
+	};
+	Azure::Core::Credentials::AccessToken raw_token;
+};
+
+class AzureSecret : public BaseKeyValueSecret {
+public:
+	static case_insensitive_set_t GetRedactionSet() {
+		return {"connection_string"};
+	}
+	AzureSecret(BaseKeyValueSecret &secret) : BaseKeyValueSecret(secret) {
+		redact_keys = GetRedactionSet();
+	};
+	AzureSecret(BaseSecret &secret) : BaseKeyValueSecret(secret) {
+		redact_keys = GetRedactionSet();
+	};
+	AzureSecret(vector<string> &prefix_paths_p, string &type, string &provider, string &name)
+	    : BaseKeyValueSecret(prefix_paths_p, type, provider, name) {
+		redact_keys = GetRedactionSet();
+	};
+
+	unique_ptr<Azure::Storage::Blobs::BlobContainerClient> GetContainerClient(AzureParsedUrl &url) const {
+		if (secret_map.find("connection_string") != secret_map.end()) {
+			return make_uniq<Azure::Storage::Blobs::BlobContainerClient>(
+			    Azure::Storage::Blobs::BlobContainerClient::CreateFromConnectionString(secret_map.at("connection_string"), url.container));
+		}
+
+		if (secret_map.find("credential_chain") != secret_map.end()) {
+			auto raw_token_credential = make_shared<RawTokenCredential>(name);
+			raw_token_credential->raw_token.Token = secret_map.at("current_token");
+			raw_token_credential->raw_token.ExpiresOn = Azure::DateTime::Parse(secret_map.at("expires_on"), Azure::DateTime::DateFormat::Rfc3339);
+
+			string azure_endpoint = secret_map.at("endpoint");
+			if (azure_endpoint.empty()) {
+				azure_endpoint = "blob.core.windows.net";
+			}
+
+			auto accountURL = "https://" + secret_map.at("account_name") + "." + azure_endpoint;
+			Azure::Storage::Blobs::BlobServiceClient blob_service_client(accountURL, raw_token_credential);
+			return make_uniq<Azure::Storage::Blobs::BlobContainerClient>(blob_service_client.GetBlobContainerClient(url.container));
+		}
+
+		return nullptr;
+	}
+
+	void SetConnectionString(const string& connection_string) {
+		secret_map["connection_string"] = connection_string;
+	}
+
+	void SetCredentialChainToken(const string& credential_chain, const string& account_name, const string& current_token, const string& expires_on, const string& endpoint = "") {
+		secret_map["credential_chain"] = credential_chain;
+		secret_map["account_name"] = account_name;
+		secret_map["current_token"] = current_token;
+		secret_map["expires_on"] = expires_on;
+		secret_map["endpoint"] = endpoint;
+	}
+};
+
+struct CreateAzureSecretFunctions {
+public:
+	//! Register all CreateSecretFunctions
+	static void Register(DatabaseInstance &instance);
+};
+
+} // namespace duckdb

--- a/test/sql/azure_auth_local.test
+++ b/test/sql/azure_auth_local.test
@@ -30,9 +30,9 @@ SELECT count(*) FROM 'azure://testing-public/l1.parquet';
 60175
 
 query I
-SELECT count(*) FROM 'azure://testing-public/l*.parquet';
+SELECT count(*) FROM 'azure://testing-public/l[12].parquet';
 ----
-180525
+120350
 
 # With the CLI credentials, private authentication should now work
 query I
@@ -41,9 +41,9 @@ SELECT count(*) FROM 'azure://testing-private/l1.parquet';
 60175
 
 query I
-SELECT count(*) FROM 'azure://testing-private/l*.parquet';
+SELECT count(*) FROM 'azure://testing-private/l[12].parquet';
 ----
-180525
+120350
 
 # No credential providers, public buckets should still work!
 statement ok
@@ -55,9 +55,9 @@ SELECT count(*) FROM 'azure://testing-public/l1.parquet';
 60175
 
 query I
-SELECT count(*) FROM 'azure://testing-public/l*.parquet';
+SELECT count(*) FROM 'azure://testing-public/l[12].parquet';
 ----
-180525
+120350
 
 # private without credentials don't work
 statement error
@@ -82,12 +82,14 @@ SELECT count(*) FROM 'azure://testing-private/l1.parquet';
 60175
 
 query I
-SELECT count(*) FROM 'azure://testing-private/l*.parquet';
+SELECT count(*) FROM 'azure://testing-private/l[12].parquet';
 ----
-180525
+120350
 
 statement ok
 set azure_endpoint='nop.nop';
 
 statement error
-SELECT count(*) FROM 'azure://testing-private/l*.parquet';
+SELECT count(*) FROM 'azure://testing-private/l[12].parquet';
+----
+Fail to get a new connection for: https://duckdbtesting.nop.nop. Couldn't resolve host name

--- a/test/sql/azure_auth_local_secrets.test
+++ b/test/sql/azure_auth_local_secrets.test
@@ -10,6 +10,9 @@ require-env DUCKDB_CLI_TEST_ENV_AVAILABLE
 
 load __TEST_DIR__/azure_auth_local_secrets.db
 
+statement ok
+set secret_directory='__TEST_DIR__/azure_auth_local_secrets'
+
 # Note: this test is currently not run in CI as it requires setting up quite a bit of setup.
 #       for now, to run this test locally, ensure you have access to the duckdbtesting storage
 #       account, then login through the cli. Then running the test with DUCKDB_CLI_TEST_ENV_AVAILABLE=1
@@ -19,7 +22,7 @@ load __TEST_DIR__/azure_auth_local_secrets.db
 #       service principals
 
 statement ok
-CREATE PERMANENT SECRET s1 (
+CREATE PERSISTENT SECRET az1 (
     TYPE AZURE,
     PROVIDER CREDENTIAL_CHAIN,
     ACCOUNT_NAME 'duckdbtesting'
@@ -33,9 +36,72 @@ SELECT count(*) FROM 'azure://testing-private/l1.parquet';
 
 restart
 
+statement ok
+set secret_directory='__TEST_DIR__/azure_auth_local_secrets'
+
 # The credentials are persistent!
 query I
-SELECT count(*) FROM 'azure://testing-private/l*.parquet';
+SELECT count(*) FROM 'azure://testing-private/l[12].parquet';
 ----
-180525
+120350
 
+statement ok
+DROP SECRET az1;
+
+# This is the default config provider: it will allow access to public azure urls
+statement ok
+CREATE SECRET az1 (
+    TYPE AZURE,
+    ACCOUNT_NAME 'duckdbtesting'
+)
+
+query I
+SELECT count(*) FROM 'azure://testing-public/l1.parquet';
+----
+60175
+
+statement error
+SELECT count(*) FROM 'azure://testing-private/l1.parquet';
+----
+failed to authenticate the request
+
+statement ok
+DROP SECRET az1;
+
+# Now use the credential provider with a chain that won't work
+statement ok
+CREATE PERSISTENT SECRET az1 (
+    TYPE AZURE,
+    PROVIDER CREDENTIAL_CHAIN,
+    CHAIN 'env',
+    ACCOUNT_NAME 'duckdbtesting'
+)
+
+statement error
+SELECT count(*) FROM 'azure://testing-private/l1.parquet';
+----
+IO Error: AzureStorageFileSystem could not open file: 'azure://testing-private/l1.parquet', unknown error occured, this could mean the credentials used were wrong. Original error message: 'Failed to get token from ChainedTokenCredential.'
+
+# Currently, when providing a credential provider secret that does not yield a token, even public request fail
+statement error
+SELECT count(*) FROM 'azure://testing-public/l1.parquet';
+----
+IO Error: AzureStorageFileSystem could not open file: 'azure://testing-public/l1.parquet', unknown error occured, this could mean the credentials used were wrong. Original error message: 'Failed to get token from ChainedTokenCredential.'
+
+statement ok
+DROP SECRET az1
+
+# Now use the credential provider with the provider that does work
+statement ok
+CREATE PERSISTENT SECRET az1 (
+    TYPE AZURE,
+    PROVIDER CREDENTIAL_CHAIN,
+    CHAIN 'cli',
+    ACCOUNT_NAME 'duckdbtesting'
+)
+
+# Auth works again!
+query I
+SELECT count(*) FROM 'azure://testing-private/l1.parquet';
+----
+60175

--- a/test/sql/azure_auth_local_secrets.test
+++ b/test/sql/azure_auth_local_secrets.test
@@ -1,0 +1,41 @@
+# name: test/sql/azure_auth_local_secrets.test
+# description: test azure extension authentication
+# group: [azure]
+
+require azure
+
+require parquet
+
+require-env DUCKDB_CLI_TEST_ENV_AVAILABLE
+
+load __TEST_DIR__/azure_auth_local_secrets.db
+
+# Note: this test is currently not run in CI as it requires setting up quite a bit of setup.
+#       for now, to run this test locally, ensure you have access to the duckdbtesting storage
+#       account, then login through the cli. Then running the test with DUCKDB_CLI_TEST_ENV_AVAILABLE=1
+#       should give all green!
+#
+# TODO: We should setup a key in CI to automatically test this. Ideally that would also involve Managed identities and
+#       service principals
+
+statement ok
+CREATE PERMANENT SECRET s1 (
+    TYPE AZURE,
+    PROVIDER CREDENTIAL_CHAIN,
+    ACCOUNT_NAME 'duckdbtesting'
+)
+
+# With the CLI credentials, private authentication should now work
+query I
+SELECT count(*) FROM 'azure://testing-private/l1.parquet';
+----
+60175
+
+restart
+
+# The credentials are persistent!
+query I
+SELECT count(*) FROM 'azure://testing-private/l*.parquet';
+----
+180525
+

--- a/test/sql/azure_secret.test
+++ b/test/sql/azure_secret.test
@@ -1,0 +1,58 @@
+# name: test/sql/azure_secret.test
+# description: test azure extension secrets
+# group: [azure]
+
+# Require statement will ensure this test is run with this extension loaded
+require azure
+
+require parquet
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+# We need a connection string to do requests
+foreach prefix azure:// az://
+
+statement error
+SELECT sum(l_orderkey) FROM '${prefix}testing-private/l.parquet';
+----
+Invalid Input Error: No valid Azure credentials found
+
+# Start with default provider
+statement ok
+CREATE SECRET s1 (
+    TYPE AZURE,
+    CONNECTION_STRING '${AZURE_STORAGE_CONNECTION_STRING}'
+)
+
+# Read a column from a parquet file
+query I
+SELECT sum(l_orderkey) FROM '${prefix}testing-private/l.parquet';
+----
+1802759573
+
+# Remove secret
+statement ok
+DROP SECRET s1
+
+endloop
+
+statement error
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
+
+# Explicit provider, and a scope
+statement ok
+CREATE SECRET s1 (
+    TYPE AZURE,
+    PROVIDER CONNECTION_STRING,
+    SCOPE 'az://testing-private',
+    CONNECTION_STRING '${AZURE_STORAGE_CONNECTION_STRING}'
+)
+
+# Only matching scope works
+statement error
+SELECT sum(l_orderkey) FROM 'azure://testing-private/l.parquet';
+
+query I
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
+----
+1802759573

--- a/test/sql/azure_secret.test
+++ b/test/sql/azure_secret.test
@@ -38,12 +38,14 @@ endloop
 
 statement error
 SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
+----
+Invalid Input Error: No valid Azure credentials found
 
 # Explicit provider, and a scope
 statement ok
 CREATE SECRET s1 (
     TYPE AZURE,
-    PROVIDER CONNECTION_STRING,
+    PROVIDER CONFIG,
     SCOPE 'az://testing-private',
     CONNECTION_STRING '${AZURE_STORAGE_CONNECTION_STRING}'
 )
@@ -51,6 +53,8 @@ CREATE SECRET s1 (
 # Only matching scope works
 statement error
 SELECT sum(l_orderkey) FROM 'azure://testing-private/l.parquet';
+----
+Invalid Input Error: No valid Azure credentials found
 
 query I
 SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';


### PR DESCRIPTION
This PR adds support for a new concept in duckdb: secrets (https://github.com/duckdb/duckdb/pull/10042)

To summarize, secrets are, in the most generic sense, scoped sets of configuration that provide the necessary information to do something. In most cases this "something" will be an authorized request to some API.

For the Azure extension this means the what was previously configured through duckdb settings, will now be done through secrets. 

##  Added secret providers
This PR adds the `azure` secret type with 2 secret providers: `config` and `credential_chain`

### Config provider
the `config` provider is **the default provider** for azure secrets. It can be used in two ways:

Firstly it can be used to specify an account name for public accessible azure storage urls:
```
CREATE SECRET (
    TYPE AZURE,
    ACCOUNT_NAME 'duckdbtesting'
)

FROM 'az://some-public/stuff.parquet'
```

Secondly, it can be used with the CONNECTION_STRING param to query from authenticated places:
```
CREATE SECRET s1 (
    TYPE AZURE,
    CONNECTION_STRING '${AZURE_STORAGE_CONNECTION_STRING}'
)

FROM 'az://some-private/stuff.parquet'
```

### credential_chain provider
The `credential_chain` azure secret provider can be used similar to what is being added in the aws extension now as well https://github.com/duckdb/duckdb_aws/pull/23. Basically it allows to either just use the default Azure SDK credential chain, or specify a custom chain.

To create a secret that uses the default credential chain:
```
CREATE SECRET (
    TYPE AZURE,
    PROVIDER CREDENTIAL_CHAIN,
    ACCOUNT_NAME 'some-account'
)

FROM 'az://some-private/stuff.parquet'
```

Or to specify to only use the CLI and env providers, in that order:
```
CREATE SECRET (
    TYPE AZURE,
    PROVIDER CREDENTIAL_CHAIN,
    CHAIN 'cli;env',
    ACCOUNT_NAME 'some-account'
)

FROM 'az://some-private/stuff.parquet'
```

Note: CI is still a bit of a work in progress here, some things are testable only manually ATM, I leave that to future work
