### PR TITLE
Add Workload Identity Credentials

### DIFF
--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -27,7 +27,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 	    LogicalType::VARCHAR);
 	config.AddExtensionOption("azure_credential_chain",
 	                          "Ordered list of Azure credential providers, in string format separated by ';'. E.g. "
-	                          "'cli;managed_identity;env'",
+	                          "'cli;workload_identity;managed_identity;env'",
 	                          LogicalType::VARCHAR, nullptr);
 	config.AddExtensionOption("azure_endpoint",
 	                          "Override the azure endpoint for when the Azure credential providers are used.",

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -22,6 +22,7 @@
 #include <azure/identity/default_azure_credential.hpp>
 #include <azure/identity/environment_credential.hpp>
 #include <azure/identity/managed_identity_credential.hpp>
+#include <azure/identity/workload_identity_credential.hpp>
 #include <azure/storage/blobs/blob_options.hpp>
 #include <azure/storage/blobs/blob_service_client.hpp>
 
@@ -138,6 +139,8 @@ CreateChainedTokenCredential(const std::string &chain,
 	for (const auto &item : chain_list) {
 		if (item == "cli") {
 			sources.push_back(std::make_shared<Azure::Identity::AzureCliCredential>(credential_options));
+		} else if (item == "workload_identity") {
+			sources.push_back(std::make_shared<Azure::Identity::WorkloadIdentityCredential>(credential_options));
 		} else if (item == "managed_identity") {
 			sources.push_back(std::make_shared<Azure::Identity::ManagedIdentityCredential>(credential_options));
 		} else if (item == "env") {


### PR DESCRIPTION
Hello, I would like to discuss adding option for using Workload Identity credentials.
From my (very limited) point of view, adding support is straight-forward as the `WorkloadIdentityCredential` is part of `DefaultAzureCredential` since 1.6.0: https://github.com/Azure/azure-sdk-for-cpp/issues/4906

Notes:
- I am a Python developer, who did last C++ project 12 years ago.
- I was able to build the code, but I haven't tested it properly (Managed Identity has no tests as well). 
- I would love to test the extension on my kubernetes workloads. 
- Do I need to cross-compile it? I have a mac, but our workloads are based on [python/3.12-slim](https://hub.docker.com/layers/library/python/3.12-slim/images/sha256-ac212230555ffb7ec17c214fb4cf036ced11b30b5b460994376b0725c7f6c151) image.
  - Could you please give me an advice what is the easiest way to do it?
  - Is there any chance the extension could be built in CI as pre-release in order to test it?

Sorry if the code is not up to standards, any suggestions how to improve it are very welcome. 
