### PR TITLE
Allow overwriting C++ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,8 @@ if(NOT ${azure-identity-cpp_FOUND}
   message(FATAL_ERROR "Azure SDK not found, did you set up vcpkg correctly?")
 endif()
 
-target_compile_features(${EXTENSION_NAME} PUBLIC cxx_std_14)
-target_compile_features(${LOADABLE_EXTENSION_NAME} PUBLIC cxx_std_14)
-set_target_properties(${EXTENSION_NAME} ${LOADABLE_EXTENSION_NAME} PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-)
-
 # Static lib
+target_compile_features(${EXTENSION_NAME} PUBLIC cxx_std_14)
 target_link_libraries(
   ${EXTENSION_NAME} Azure::azure-identity Azure::azure-storage-blobs
   Azure::azure-storage-files-datalake)
@@ -48,6 +43,7 @@ target_include_directories(
                             Azure::azure-storage-files-datalake)
 
 # Loadable binary
+target_compile_features(${LOADABLE_EXTENSION_NAME} PUBLIC cxx_std_14)
 target_link_libraries(
   ${LOADABLE_EXTENSION_NAME} Azure::azure-identity
   Azure::azure-storage-blobs Azure::azure-storage-files-datalake)


### PR DESCRIPTION
Makes CMAKE_CXX_STANDARD a cached variable so that it is possible to overwrite the C++ version with which it is build from a parent CMake project or the command line CMake call.