### PR TITLE
add alternative ids for managed identity: resource_id and object_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ CREATE SECRET secret5 (
 );
 ```
 
-## Managed Identity with User-assigned ID (UAMI)
+### Managed Identity with User-assigned ID (UAMI)
 
 ```sql
 CREATE SECRET secret1 (
     TYPE AZURE,
-    PROVIDER managed_identity,
-    ACCOUNT_NAME '⟨storage account name⟩'
+    PROVIDER MANAGED_IDENTITY,
+    ACCOUNT_NAME '⟨storage account name⟩',
     CLIENT_ID '⟨used-assigned managed identity client id⟩'
 );
 ```
@@ -93,6 +93,9 @@ CREATE SECRET secret1 (
 `CLIENT_ID` is optional; if not specified, the Azure SDK will attempt to find and use either a
 System-assigned Managed Identity (SAMI) or User-assigned Managed Identity (UAMI). If both are
 defined, or more than 1 UAMI is available, order and behavior is undefined.
+
+Alternatively, `OBJECT_ID` or `RESOURCE_ID` may be used instead of `CLIENT_ID`. Only 1 of these
+IDs may be specified.
 
 See also [Azure Identity Managed Identity Support](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#managed-identity-support)
 

--- a/src/azure_secret.cpp
+++ b/src/azure_secret.cpp
@@ -99,8 +99,10 @@ static unique_ptr<BaseSecret> CreateAzureSecretFromManagedIdentity(ClientContext
 		CopySecret(key, input, *result);
 	}
 
-	// Manage specific secret option
+	// Manage specific secret options
 	CopySecret("client_id", input, *result);
+	CopySecret("object_id", input, *result);
+	CopySecret("resource_id", input, *result);
 
 	// Redact sensible keys
 	RedactCommonKeys(*result);
@@ -200,6 +202,8 @@ void CreateAzureSecretFunctions::Register(ExtensionLoader &loader) {
 	// Register the managed identity secret provider
 	CreateSecretFunction managed_identity_function = {type, "managed_identity", CreateAzureSecretFromManagedIdentity};
 	managed_identity_function.named_parameters["client_id"] = LogicalType::VARCHAR;
+	managed_identity_function.named_parameters["object_id"] = LogicalType::VARCHAR;
+	managed_identity_function.named_parameters["resource_id"] = LogicalType::VARCHAR;
 	RegisterCommonSecretParameters(managed_identity_function);
 	loader.RegisterFunction(managed_identity_function);
 


### PR DESCRIPTION
Support object_id and resource_id specs for manual/specific Managed Identity binding.