### PR TITLE
add ADLSv2/DFS/abfss writes

### DIFF
--- a/.github/workflows/CloudTesting.yml
+++ b/.github/workflows/CloudTesting.yml
@@ -16,17 +16,13 @@ jobs:
     name: Azure tests (Linux)
     runs-on: ubuntu-latest
     env:
+      # NOTE: container/authn env is managed in scripts/env_azure so that local test
+      # runs are easily managed; actual secrets are still loaded here via 1password in
+      # an early workflow step
       VCPKG_TARGET_TRIPLET: x64-linux
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       GEN: ninja
       DUCKDB_PLATFORM: linux_amd64
-      # AZ protocol vars
-      AZ_STORAGE_ACCOUNT: duckdblabstestdatablob
-      AZ_DATA_DIR: duckdblabs-data/common/azure_data
-      AZ_TEMP_DIR: duckdblabs-write-testing/extension/azure
-      # ABFSS protocol vars
-      ABFSS_STORAGE_ACCOUNT: duckdblabstestdata
-      ABFSS_DATA_DIR: duckdblabs-data/common/azure_data
 
     steps:
       - name: Install required ubuntu packages
@@ -43,9 +39,9 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          AZURE_TENANT_ID: op://testing/azure/tenant_id
-          AZURE_CLIENT_ID: op://testing/azure/client_id
-          AZURE_CLIENT_SECRET: op://testing/azure/client_secret
+          AZURE_TENANT_ID: op://testing-rw/azure/tenant_id
+          AZURE_CLIENT_ID: op://testing-rw/azure/client_id
+          AZURE_CLIENT_SECRET: op://testing-rw/azure/client_secret
           AZURE_AUTH_ENV: 1
 
       - uses: actions/checkout@v3
@@ -73,23 +69,23 @@ jobs:
         run: |
           make release
 
-      - name: Test with Service Principal (SPN) in env vars
+      - name: Test with Service Principal (SPN) in env vars (!=slow)
         run: |
-          python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest "test/sql/cloud/*"
+          scripts/env_azure ./build/release/test/unittest --skip-tag slow "test/sql/cloud/*"
 
       - name: Test with SPN logged in in azure-cli
         env:
           DUCKDB_AZ_CLI_LOGGED_IN: 1
-
         run: |
+          # note: first CLI login, then allow env_azure to setup several key (non secret) vars, then clear SECRET after env script
+          # to prevent accidental use of env secrets.
           az login --service-principal --user="${AZURE_CLIENT_ID}" --password="${AZURE_CLIENT_SECRET}" --tenant="${AZURE_TENANT_ID}"
-          unset AZURE_CLIENT_SECRET # prevent env usage going forward
-          python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest "test/sql/cloud/*"
+          scripts/env_azure env -u AZURE_CLIENT_SECRET ./build/release/test/unittest "test/sql/cloud/azure_writes.test"
 
-      - name: Test with access token
+      - name: Test with access token (created via CLI, logged in above)
         run: |
           export AZURE_ACCESS_TOKEN=`az account get-access-token --resource https://storage.azure.com --query accessToken --output tsv`
-          ./build/release/test/unittest "test/sql/cloud/access_token_auth.test"
+          scripts/env_azure env -u AZURE_CLIENT_SECRET ./build/release/test/unittest "test/sql/cloud/access_token_auth.test"
 
       - name: Clean credentials
         if: always()
@@ -100,15 +96,21 @@ jobs:
         env:
           DUCKDB_AZURE_PUBLIC_CONTAINER_AVAILABLE: 1
           PUBLIC_AZ_STORAGE_ACCOUNT: duckdbtesting
-      
         run: |
-          python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest "test/sql/cloud/unauthenticated"
+          env -u AZURE_CLIENT_SECRET ./build/release/test/unittest "test/sql/cloud/unauthenticated.test"
 
       - name: Run test data integrity check
+        env:
+          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE: 1 
         run: |
-          ./build/release/duckdb -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, PROVIDER SERVICE_PRINCIPAL, TENANT_ID '${{secrets.AZURE_TENANT_ID}}', CLIENT_ID '${{secrets.AZURE_CLIENT_ID}}', CLIENT_SECRET '${{secrets.AZURE_CLIENT_SECRET}}', ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}')"
-          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 ./build/release/test/unittest "test/sql/test_data_integrity.test"
+          scripts/env_azure ./build/release/duckdb -c "CREATE PERSISTENT SECRET az_authn_persistent (TYPE AZURE, PROVIDER SERVICE_PRINCIPAL, TENANT_ID '${{secrets.AZURE_TENANT_ID}}', CLIENT_ID '${{secrets.AZURE_CLIENT_ID}}', CLIENT_SECRET '${{secrets.AZURE_CLIENT_SECRET}}', ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}', SCOPE 'az://')"
+          scripts/env_azure ./build/release/test/unittest "test/sql/test_data_integrity.test"
 
-      #- name: Setup tmate session
-      #  if: ${{ failure() }}
-      #  uses: mxschmitt/action-tmate@v3
+      - name: Test with Service Principal (SPN) in env vars (==slow)
+        run: |
+          scripts/env_azure ./build/release/test/unittest --select-tag slow "test/sql/cloud/*"
+
+      # XXX: remove me before landing
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/LocalTesting.yml
+++ b/.github/workflows/LocalTesting.yml
@@ -69,12 +69,12 @@ jobs:
 
     - name: Test extension
       run: |
-        make test
+        scripts/env_azurite make test
 
     - name: Run test data integrity check
       run: |
         ./build/release/duckdb -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, CONNECTION_STRING '$AZURE_STORAGE_CONNECTION_STRING')"
-        DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 ./build/release/test/unittest "*test/sql/test_data_integrity.test"
+        DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 scripts/env_azurite ./build/release/test/unittest "*test/sql/test_data_integrity.test"
 
     - name: Azure test server log
       if: always()
@@ -139,12 +139,12 @@ jobs:
       - name: Test Extension
         shell: bash
         run: |
-          make test
+          scripts/env_azurite make test
 
       - name: Run test data integrity check
         run: |
           ./build/release/duckdb -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, CONNECTION_STRING '$AZURE_STORAGE_CONNECTION_STRING')"
-          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 ./build/release/test/unittest "*test/sql/test_data_integrity.test"
+          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 scripts/env_azurite ./build/release/test/unittest "*test/sql/test_data_integrity.test"
 
       - name: Azure test server log
         if: always()
@@ -205,14 +205,14 @@ jobs:
       - name: Test Extension
         shell: bash
         run: |
-          build/release/test/Release/unittest.exe --test-dir . "[sql]"
+          scripts/env_azurite build/release/test/Release/unittest.exe --test-dir . "[sql]"
 
       - name: Run test data integrity check
         run: |
           ls build
           ls build/release
           ./build/release/Release/duckdb.exe -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, CONNECTION_STRING '$AZURE_STORAGE_CONNECTION_STRING')"
-          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 build/release/test/Release/unittest.exe "*test/sql/test_data_integrity.test"
+          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 scripts/env_azurite build/release/test/Release/unittest.exe "*test/sql/test_data_integrity.test"
 
       - name: Azure test server log
         if: always()

--- a/scripts/env_azure
+++ b/scripts/env_azure
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+##
+# NOTE: usage -- run_azure [--az|--abfss] prog [args ...]
+# `prog` will receive all the environment vars necessary to authenticate and configure with
+# azure. Often run with either --az or --abfss, which sets additional envvars to execute
+# tests, e.g.
+#
+#   run_azure --az build/debug/test/unittest 'test/sql/cloud/write/*'
+#
+# When credentials are not already set, they will be fetched via op injection.
+#
+# File can also be sourced to set env in current bash/zsh-like shell.
+#
+
+# if secret unset, fetch from 1Password
+[[ -z "$AZURE_CLIENT_SECRET" || -z "$AZURE_CLIENT_ID" || -z "$AZURE_TENANT_ID" ]] && {
+	echo "Azure AuthN missing from env; fetching Azure secrets from 1password."
+	exports=$(op read op://testing-rw/azure/_env | op inject)
+	# be slightly paranoid - no ` or $ in the env
+	echo -n "$export" | grep -e '`' -e '$' && {
+		echo 'Found unexpected ` or $ in azure secret exports from 1Password, aborting.' >&2
+		exit 1
+	}
+	eval "$exports"
+} || {
+	echo "Azure AuthN info found in env."
+}
+
+# unittest doesn't (yet) handle test dir root/suffix/etc., take the simple path to
+# avoiding collision with a date/time + small rand here
+# TODO: (maybe) move this into unittest, plus add cleanup that works w/ e.g. azure
+rand=$(python3 -c 'import uuid; print(str(uuid.uuid4())[10:17])')
+temp_dir_suffix="$USER/$(TZ=Z date +'%Y%m%dT%H%M%SZ')--$rand"
+
+export ABFSS_STORAGE_ACCOUNT=duckdblabstestdata
+export ABFSS_DATA_DIR=duckdblabs-data/common/azure_data
+export ABFSS_TEMP_DIR="duckdblabs-write-testing/extension/azure/$temp_dir_suffix"
+
+export AZ_STORAGE_ACCOUNT=duckdblabstestdatablob
+export AZ_DATA_DIR=duckdblabs-data/common/azure_data
+export AZ_TEMP_DIR="duckdblabs-write-testing/extension/azure/$temp_dir_suffix"
+
+export AZURE_AUTH_ENV=1
+export AZURE_PROVIDER=cloud
+
+[[ -n "$1" && "$1" = "--abfss" ]] && {
+	export AZURE_PROTOCOL=abfss
+	export AZURE_STORAGE_ACCOUNT="$ABFSS_STORAGE_ACCOUNT"
+	export DATA_DIR="$ABFSS_DATADIR"
+	export TEMP_DIR="$ABFSS_TEMPDIR"
+	shift
+}
+
+[[ -n "$1" && "$1" = "--az" ]] && {
+	export AZURE_PROTOCOL=az
+	export AZURE_STORAGE_ACCOUNT="$AZ_STORAGE_ACCOUNT"
+	export DATA_DIR="$AZ_DATADIR"
+	export TEMP_DIR="$AZ_TEMPDIR"
+	shift
+}
+
+exec "$@"

--- a/scripts/env_azurite
+++ b/scripts/env_azurite
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# straight from azurite docs
+export AZURE_STORAGE_ACCOUNT=devstoreaccount1
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+
+# unittest doesn't (yet) handle test dir root/suffix/etc., take the simple path to
+# avoiding collision with a date/time + small rand here
+# TODO: (maybe) move this into unittest, plus add cleanup that works w/ e.g. azure
+rand=$(python3 -c 'import uuid; print(str(uuid.uuid4())[10:17])')
+temp_dir_suffix="$USER/$(TZ=Z date +'%Y%m%dT%H%M%SZ')--$rand"
+
+unset ABFSS_STORAGE_ACCOUNT
+unset ABFSS_DATA_DIR
+unset ABFSS_TEMP_DIR
+export AZ_DATA_DIR="testing-private"
+export AZ_TEMP_DIR="writes/$temp_dir_suffix"
+export AZ_STORAGE_ACCOUNT="$AZURE_STORAGE_ACCOUNT"
+
+export AZURE_PROTOCOL=az
+export AZURE_PROVIDER=local
+export DATA_DIR="$AZ_DATADIR"
+export TEMP_DIR="$AZ_TEMPDIR"
+
+# for compatibility, accept --az arg, and fail on --abfss
+[[ -n "$1" && "$1" = "--abfss" ]] && {
+	echo "run_azurite can only operate in --az mode, aborting." >&2
+	exit
+}
+[[ -n "$1" && "$1" = "--az" ]] && {
+	# NOOP
+	shift
+}
+
+exec "$@"

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/logging/file_system_logger.hpp"
 
 #include <algorithm>
+#include <azure/storage/blobs/blob_options.hpp>
 #include <azure/storage/common/storage_exception.hpp>
 #include <azure/storage/files/datalake.hpp>
 #include <azure/storage/files/datalake/datalake_directory_client.hpp>
@@ -104,6 +105,12 @@ AzureDfsStorageFileHandle::AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &
     : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, read_options), file_client(std::move(client)) {
 }
 
+void AzureDfsStorageFileHandle::Close() {
+	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+		file_client.Flush(file_offset);
+	}
+}
+
 //////// AzureDfsStorageFileSystem ////////
 unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFileInfo &info, FileOpenFlags flags,
                                                                     optional_ptr<FileOpener> opener) {
@@ -112,9 +119,6 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 	}
 	if (flags.Compression() != FileCompressionType::UNCOMPRESSED) {
 		throw InternalException("Unsupported(INTERNAL): cannot open an Azure file in compressed mode");
-	}
-	if (flags.OpenForWriting()) {
-		throw NotImplementedException("Unsupported: cannot open an Azure file in write mode");
 	}
 	if (flags.OpenForAppending()) {
 		throw NotImplementedException("Unsupported: cannot open an Azure file in append mode");
@@ -144,13 +148,40 @@ bool AzureDfsStorageFileSystem::DirectoryExists(const string &dirname, optional_
 	return handle && handle->Cast<AzureDfsStorageFileHandle>().GetType() == FileType::FILE_TYPE_DIR;
 }
 
-void AzureDfsStorageFileSystem::CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) {
-	throw NotImplementedException("Unsupported in Azure ADLSv2: CreateDirectory");
+void AzureDfsStorageFileSystem::CreateDirectory(const string &dirname, optional_ptr<FileOpener> opener) {
+	if (!opener) {
+		throw InternalException("Unsupported(INTERNAL): cannot create an Azure directory without FileOpener");
+	}
+	auto dir_url = ParseUrl(dirname);
+	auto storage_context = GetOrCreateStorageContext(opener, dirname, dir_url);
+	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(dir_url.container);
+	file_system_client.GetDirectoryClient(dir_url.path).Create();
 }
 
 bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
 	return handle && handle->Cast<AzureDfsStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR;
+}
+
+void AzureDfsStorageFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	auto url = ParseUrl(filename);
+	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
+	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(url.container);
+	auto file_client = file_system_client.GetFileClient(url.path);
+	try {
+		file_client.Delete();
+	} catch (Azure::Storage::StorageException &e) {
+		throw IOException("AzureDfsStorageFileSystem Delete of %s failed with %s Reason Phrase: %s", filename,
+		                  e.ErrorCode, e.ReasonPhrase);
+	}
+}
+
+bool AzureDfsStorageFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	auto url = ParseUrl(filename);
+	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
+	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(url.container);
+	auto file_client = file_system_client.GetFileClient(url.path);
+	return file_client.DeleteIfExists().Value.Deleted;
 }
 
 vector<OpenFileInfo> AzureDfsStorageFileSystem::Glob(const string &path, FileOpener *opener) {
@@ -245,13 +276,45 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 		return;
 	}
 
-	auto res_props = afh.file_client.GetProperties();
-	auto is_dir = res_props.Value.IsDirectory;
-	afh.is_remote_loaded = true; // always set loaded
-	afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
-	afh.length = is_dir ? 0 : res_props.Value.FileSize;
-	afh.last_modified = ToTimestamp(res_props.Value.LastModified);
-	afh.file_offset = 0; // always reset offset state
+	// handling a couple situations here:
+	// - does exist, but want exclusive create
+	// - does exist, just get the data
+	// - does exist, truncate (same API as create)
+	// - doesn't exist, must be created (file; dir create doesn't happen here)
+	// - doesn't exist, don't create
+
+	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod) {
+		afh.is_remote_loaded = true; // always set loaded
+		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
+		afh.length = is_dir ? 0 : length;
+		afh.last_modified = last_mod;
+		afh.file_offset = 0; // always reset offset state
+	};
+
+	auto create_file = [&]() {
+		auto res_create = afh.file_client.Create();
+		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+	};
+	auto truncate_file = create_file;
+
+	try {
+		auto res_props = afh.file_client.GetProperties();
+		if (afh.flags.ExclusiveCreate()) {
+			throw IOException("AzureDfsStorageFileSystem will not open file: '%s', ExclusiveCreate specified "
+			                  "while file already exists.");
+		} else if (afh.flags.OpenForWriting() && afh.flags.OverwriteExistingFile()) {
+			return truncate_file();
+		}
+		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
+		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/") || res_props.Value.IsDirectory;
+		return set_props(is_dir, res_props.Value.FileSize, ToTimestamp(res_props.Value.LastModified));
+	} catch (const Azure::Storage::StorageException &e) {
+		if (int(e.StatusCode) == 404 && afh.flags.OpenForWriting() &&
+		    (afh.flags.OverwriteExistingFile() || afh.flags.CreateFileIfNotExists())) {
+			return create_file();
+		}
+		throw;
+	}
 }
 
 void AzureDfsStorageFileSystem::ReadRange(AzureFileHandle &handle, idx_t file_offset, char *buffer_out,
@@ -282,6 +345,48 @@ shared_ptr<AzureContextState> AzureDfsStorageFileSystem::CreateStorageContext(op
 
 	return make_shared_ptr<AzureDfsContextState>(ConnectToDfsStorageAccount(opener, path, parsed_url),
 	                                             azure_read_options);
+}
+
+int64_t AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &afh = handle.Cast<AzureDfsStorageFileHandle>();
+	Write(handle, buffer, nr_bytes, afh.file_offset);
+	return nr_bytes;
+}
+
+void AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	D_ASSERT(nr_bytes >= 0);
+	auto &afh = handle.Cast<AzureDfsStorageFileHandle>();
+	D_ASSERT(afh.file_offset + nr_bytes > afh.file_offset); // no overflow
+
+	if (!(afh.flags.OpenForWriting() || afh.flags.OpenForAppending())) {
+		throw InternalException("Write called on file opened in read mode");
+	}
+
+	if (location != afh.file_offset || location != afh.length) {
+		throw InternalException("Write supported only sequentially or at location=0");
+	}
+
+	DUCKDB_LOG_FILE_SYSTEM_WRITE(handle, nr_bytes, afh.file_offset - nr_bytes);
+
+	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
+	if (location == 0) {
+	}
+	Azure::Storage::Files::DataLake::AppendFileOptions append_opts;
+	append_opts.Flush = true;
+	auto append_res = afh.file_client.Append(body_stream, afh.file_offset);
+	// auto flush_res = afh.file_client.Flush(afh.file_offset + nr_bytes);
+	// afh.last_modified = ToTimestamp(flush_res.Value.LastModified);
+	// D_ASSERT(idx_t(flush_res.Value.FileSize) == afh.file_offset + nr_bytes);
+	afh.file_offset += nr_bytes;
+	afh.length += nr_bytes;
+}
+
+void AzureDfsStorageFileSystem::FileSync(FileHandle &handle) {
+	// TODO: (@benfleis): uncomment these, and remove from Write to make it async
+	// auto flush_res = afh.file_client.Flush(afh.file_offset);
+	// afh.last_modified = ToTimestamp(flush_res.Value.LastModified);
+	// D_ASSERT(flush_res.Value.FileSize == afh.file_offset);
+	return;
 }
 
 } // namespace duckdb

--- a/src/include/azure_dfs_filesystem.hpp
+++ b/src/include/azure_dfs_filesystem.hpp
@@ -33,6 +33,8 @@ public:
 	                          Azure::Storage::Files::DataLake::DataLakeFileClient client);
 	~AzureDfsStorageFileHandle() override = default;
 
+	void Close() override;
+
 public:
 	Azure::Storage::Files::DataLake::DataLakeFileClient file_client;
 };
@@ -56,6 +58,12 @@ public:
 
 	// From AzureFilesystem
 	void LoadRemoteFileInfo(AzureFileHandle &handle) override;
+	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	void FileSync(FileHandle &handle) override;
+
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
+	virtual bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
 
 public:
 	static const string SCHEME;

--- a/test/sql/cloud/azure_writes.test
+++ b/test/sql/cloud/azure_writes.test
@@ -6,6 +6,10 @@ require azure
 
 require parquet
 
+require-env ABFSS_TEMP_DIR
+
+require-env ABFSS_STORAGE_ACCOUNT
+
 require-env AZ_TEMP_DIR
 
 require-env AZ_STORAGE_ACCOUNT
@@ -13,26 +17,37 @@ require-env AZ_STORAGE_ACCOUNT
 require-env AZURE_AUTH_ENV 1
 
 statement ok
-CREATE SECRET az1 (
-    TYPE AZURE,
-    PROVIDER CREDENTIAL_CHAIN,
-    ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}'
-)
+CREATE OR REPLACE SECRET abfss_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${ABFSS_STORAGE_ACCOUNT}',
+	SCOPE 'abfss://'
+);
+
+statement ok
+CREATE OR REPLACE SECRET az_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}',
+	SCOPE 'az://'
+);
+
+foreach proto abfss az
 
 ## Basic write & read
 query I
-COPY (SELECT id: 42) TO 'az://${AZ_TEMP_DIR}/write-id-42.csv';
+COPY (SELECT id: 42) TO '${proto}://duckdblabs-write-testing/extension/azure/write-id-42.csv';
 ----
 1
 
 query I
-SELECT id FROM 'az://${AZ_TEMP_DIR}/write-id-42.csv';
+SELECT id FROM '${proto}://duckdblabs-write-testing/extension/azure/write-id-42.csv';
 ----
 42
 
 # load lineitem in memory for some copies
 statement ok
-CREATE TABLE lineitem AS FROM './data/l.parquet';
+CREATE TABLE IF NOT EXISTS lineitem AS FROM './data/l.parquet';
 
 # check source query
 query I
@@ -43,18 +58,18 @@ SELECT sum(l_orderkey) FROM lineitem;
 # Copy to CSV
 statement ok
 COPY lineitem
-TO 'az://${AZ_TEMP_DIR}/lineitem-copied.csv';
+TO '${proto}://duckdblabs-write-testing/extension/azure/lineitem-copied.csv';
 
 # ... and confirm result from copy
 query I
-SELECT sum(l_orderkey) FROM 'az://${AZ_TEMP_DIR}/lineitem-copied.csv';
+SELECT sum(l_orderkey) FROM '${proto}://duckdblabs-write-testing/extension/azure/lineitem-copied.csv';
 ----
 1802759573
 
 # Copy to parquet with a couple partitions
 statement ok
 COPY lineitem
-TO 'az://${AZ_TEMP_DIR}/lineitem-partitioned' (
+TO '${proto}://duckdblabs-write-testing/extension/azure/lineitem-partitioned' (
 	FORMAT 'parquet',
 	PARTITION_BY (l_linestatus),
 	OVERWRITE_OR_IGNORE true
@@ -64,7 +79,7 @@ TO 'az://${AZ_TEMP_DIR}/lineitem-partitioned' (
 query II
 SELECT sum(l_orderkey), count(DISTINCT l_linestatus)
 FROM read_parquet(
-	'az://${AZ_TEMP_DIR}/lineitem-partitioned/*/*.parquet', 
+	'${proto}://duckdblabs-write-testing/extension/azure/lineitem-partitioned/*/*.parquet', 
 	HIVE_PARTITIONING = true
 )
 ----
@@ -73,10 +88,12 @@ FROM read_parquet(
 # Confirm failure to overwrite when disabled
 statement error
 COPY lineitem
-TO 'az://${AZ_TEMP_DIR}/lineitem-partitioned' (
+TO '${proto}://duckdblabs-write-testing/extension/azure/lineitem-partitioned' (
 	FORMAT 'parquet',
 	PARTITION_BY (l_linestatus),
 	OVERWRITE false
 );
 ----
 is not empty
+
+endloop

--- a/test/sql/cloud/azure_writes_more.test_slow
+++ b/test/sql/cloud/azure_writes_more.test_slow
@@ -6,6 +6,10 @@ require azure
 
 require parquet
 
+require-env ABFSS_TEMP_DIR
+
+require-env ABFSS_STORAGE_ACCOUNT
+
 require-env AZ_TEMP_DIR
 
 require-env AZ_STORAGE_ACCOUNT
@@ -13,34 +17,38 @@ require-env AZ_STORAGE_ACCOUNT
 require-env AZURE_AUTH_ENV 1
 
 statement ok
-CREATE SECRET az1 (
-    TYPE AZURE,
-    PROVIDER CREDENTIAL_CHAIN,
-    ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}'
-)
-
-## Many small writes - 1k
-foreach i 0 1 2 3 4 5 6 7 8 9
-
-foreach j 0 1 2 3 4 5 6 7 8 9
-
-foreach k 0 1 2 3 4 5 6 7 8 9
+CREATE OR REPLACE SECRET abfss_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${ABFSS_STORAGE_ACCOUNT}',
+	SCOPE 'abfss://'
+);
 
 statement ok
-COPY (SELECT id: '${i}${j}${k}'::INT) 
-TO 'az://${AZ_TEMP_DIR}/many/write-sequential-${i}${j}${k}.csv';
+CREATE OR REPLACE SECRET az_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}',
+	SCOPE 'az://'
+);
 
-endloop
+## Some small writes - 10k, via 100 threads
+concurrentloop i 0 100
 
-endloop
+statement ok
+COPY (
+	SELECT id: ('${i}'::INT * 100) + generate_series
+	FROM generate_series(0, 99)
+)
+TO 'az://duckdblabs-write-testing/extension/azure/many/write-concurrent-${i}.csv';
 
 endloop
 
 # Read it back as a sum: n*(n+1) / 2
 query I 
-SELECT sum(id) FROM 'az://${AZ_TEMP_DIR}/many/write-sequential-*.csv';
+SELECT sum(id) FROM 'az://duckdblabs-write-testing/extension/azure/many/write-concurrent-*.csv';
 ----
-499500
+49995000
 
 
 ## Some small writes - 10k, via 100 threads
@@ -51,20 +59,45 @@ COPY (
 	SELECT id: ('${i}'::INT * 100) + generate_series
 	FROM generate_series(0, 99)
 )
-TO 'az://${AZ_TEMP_DIR}/many/write-concurrent-${i}.csv';
+TO 'abfss://duckdblabs-write-testing/extension/azure/many/write-concurrent-${i}.csv';
 
 endloop
 
 # Read it back as a sum: n*(n+1) / 2
 query I 
-SELECT sum(id) FROM 'az://${AZ_TEMP_DIR}/many/write-concurrent-*.csv';
+SELECT sum(id) FROM 'abfss://duckdblabs-write-testing/extension/azure/many/write-concurrent-*.csv';
 ----
 49995000
+
+foreach proto abfss az
+
+## Many small writes - 1k
+foreach i 0 1 2 3 4 5 6 7 8 9
+
+foreach j 0 1 2 3 4 5 6 7 8 9
+
+foreach k 0 1 2 3 4 5 6 7 8 9
+
+statement ok
+COPY (SELECT id: '${i}${j}${k}'::INT) 
+TO '${proto}://duckdblabs-write-testing/extension/azure/many/write-sequential-${i}${j}${k}.csv';
+
+endloop
+
+endloop
+
+endloop
+
+# Read it back as a sum: n*(n+1) / 2
+query I 
+SELECT sum(id) FROM '${proto}://duckdblabs-write-testing/extension/azure/many/write-sequential-*.csv';
+----
+499500
 
 
 ## Now go for some bigger files
 statement ok
-CREATE TABLE lineitem AS FROM './data/l.parquet';
+CREATE TABLE IF NOT EXISTS lineitem AS FROM './data/l.parquet';
 
 # check source query
 query I
@@ -75,18 +108,18 @@ SELECT sum(l_orderkey) FROM lineitem;
 # Now the big copy, csv file
 statement ok
 COPY (FROM lineitem CROSS JOIN generate_series(1, 10))
-TO 'az://${AZ_TEMP_DIR}/big/lineitem.csv';
+TO '${proto}://duckdblabs-write-testing/extension/azure/big/lineitem.csv';
 
 # and confirm result from copy
 query I
-SELECT sum(l_orderkey) FROM 'az://${AZ_TEMP_DIR}/big/lineitem.csv';
+SELECT sum(l_orderkey) FROM '${proto}://duckdblabs-write-testing/extension/azure/big/lineitem.csv';
 ----
 18027595730
 
 # Finale: Same but different -- csv -> parquet, and hive partitioned
 statement ok
 COPY (FROM lineitem CROSS JOIN generate_series(1, 10))
-TO 'az://${AZ_TEMP_DIR}/big/lineitem-partitioned' (
+TO '${proto}://duckdblabs-write-testing/extension/azure/big/lineitem-partitioned' (
 	FORMAT 'parquet',
 	PARTITION_BY (l_returnflag, l_linestatus),
 	OVERWRITE_OR_IGNORE true
@@ -96,8 +129,10 @@ TO 'az://${AZ_TEMP_DIR}/big/lineitem-partitioned' (
 query I
 SELECT sum(l_orderkey) 
 FROM read_parquet(
-	'az://${AZ_TEMP_DIR}/big/lineitem-partitioned/*/*/*.parquet', 
+	'${proto}://duckdblabs-write-testing/extension/azure/big/lineitem-partitioned/*/*/*.parquet', 
 	HIVE_PARTITIONING = true
 )
 ----
 18027595730
+
+endloop

--- a/test/sql/cloud/unauthenticated.test
+++ b/test/sql/cloud/unauthenticated.test
@@ -30,8 +30,3 @@ FROM './data/l.parquet'
 ## Testing network activity
 statement ok
 SET azure_http_stats = true;
-
-query II
-EXPLAIN ANALYZE SELECT COUNT(*) FROM "az://testing-public/l.parquet";
-----
-analyzed_plan   <REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: [1-3].*GET\: [0-3].*PUT\: 0.*\#POST\: 0.*

--- a/test/sql/cloud/vfs_ops.test
+++ b/test/sql/cloud/vfs_ops.test
@@ -5,51 +5,46 @@
 # Require statement will ensure this test is run with this extension loaded
 require azure
 
-require-env AZURE_STORAGE_ACCOUNT
+require-env ABFSS_STORAGE_ACCOUNT
 
-require-env AZ_DATA_DIR
+require-env AZ_STORAGE_ACCOUNT
 
 require-env AZURE_AUTH_ENV 1
 
-
-# This test only confirms that FileExists gets called (not whether it's correct),
-# in response to Issue#68 -- Since Azurite doesn't support DFS there's no local
-# way to test it.
+statement ok
+CREATE OR REPLACE SECRET abfss_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${ABFSS_STORAGE_ACCOUNT}',
+	SCOPE 'abfss://'
+);
 
 statement ok
-CREATE SECRET az1 (
-    TYPE AZURE,
-    PROVIDER CREDENTIAL_CHAIN,
-    ACCOUNT_NAME '${AZURE_STORAGE_ACCOUNT}'
-)
+CREATE OR REPLACE SECRET az_authn (
+	TYPE AZURE,
+	PROVIDER CREDENTIAL_CHAIN,
+	ACCOUNT_NAME '${AZ_STORAGE_ACCOUNT}',
+	SCOPE 'az://'
+);
 
-# NOTE: previous output, only on DFS since the container check comes from within FileExists calls:
-# D INSTALL 'abfss://foo/bar/go.duckdb_extension';
-# Not implemented Error:
-# AzureDfsStorageFileSystem: FileExists is not implemented!
-#
-# Getting output that container doesn't exist/invalid storage account confirms entry into FileExists call.
+foreach proto abfss az
 
+# This test only confirms that FileExists gets called (not whether it's correct), and it's brittle at that.
 statement error
-INSTALL 'az://invalid-container/dir/ext.duckdb_extension';
+INSTALL '${proto}://invalid-container/dir/ext.duckdb_extension';
 ----
 container does not exist
 
-
+# confirm file not exist
 statement error
-INSTALL 'abfss://invalid-container/dir/ext.duckdb_extension';
+INSTALL '${proto}://duckdblabs-data/common/azure_data/non-existent.duckdb_extension';
 ----
-container does not exist
+<REGEX>:.*(blob|file) does not exist.*
 
-
-# NOTE: now test actual existance in az:// only -- abfss:// can only be a cloud test
+# and confirm file exists (doesn't load, but unnecessary to the test)
 statement error
-INSTALL 'az://testing-public/non-existent.duckdb_extension';
-----
-blob does not exist
-
-statement error
-INSTALL 'az://${AZ_DATA_DIR}/l.csv';
+INSTALL '${proto}://duckdblabs-data/common/azure_data/l.csv';
 ----
 file is not a DuckDB extension
 
+endloop


### PR DESCRIPTION
add ADLSv2/DFS/abfss writes

- consolidated/dedup'd many overlapping tests between local and cloud;
  - now single source templates provide common execution
  - at present the templating is expanded by hand, [test/Makefile] to generate
- correct blob store handling of various file flags
- add missing RemoveFile functionality to both protocols
