### PR TITLE
Fix fs client caching

### DIFF
--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -5,9 +5,10 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/logging/file_system_logger.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "include/azure_filesystem.hpp"
 
 #include <azure/storage/common/storage_exception.hpp>
+
+#include "azure_storage_account_client.hpp"
 
 namespace duckdb {
 
@@ -187,6 +188,44 @@ int64_t AzureStorageFileSystem::Read(FileHandle &handle, void *buffer, int64_t n
 	return nr_bytes;
 }
 
+static string GetContextKeyPath(optional_ptr<FileOpener> opener, const string &path, const AzureParsedUrl &parsed) {
+	// context key == proto://{storage_account}{.}{endpoint}
+	// when storage account / endpoint unavailable, try to fetch via secret manager
+	string account;
+	string endpoint;
+
+	if (parsed.is_fully_qualified) {
+		account = parsed.storage_account_name;
+		endpoint = parsed.endpoint;
+	} else {
+		// no storage account? map it from the secret if possible
+		auto secret_match = LookupSecret(opener, path);
+		if (secret_match.HasMatch()) {
+			const auto &secret = dynamic_cast<const KeyValueSecret &>(secret_match.GetSecret());
+
+			const auto account_from_secret = secret.TryGetValue("account_name", false);
+			if (!account_from_secret.IsNull()) {
+				account = account_from_secret.ToString();
+			}
+			const auto endpoint_from_secret = secret.TryGetValue("endpoint", false);
+			if (!endpoint_from_secret.IsNull()) {
+				endpoint = endpoint_from_secret.ToString();
+			}
+		}
+	}
+
+	// build key from account and/or endpoint, ow return ""
+	const auto has_account = !account.empty();
+	const auto has_endpoint = !endpoint.empty();
+	if (!has_account && !has_endpoint) {
+		return "";
+	}
+	if (has_account && has_endpoint) {
+		return account + "." + endpoint;
+	}
+	return has_account ? account : endpoint;
+}
+
 shared_ptr<AzureContextState> AzureStorageFileSystem::GetOrCreateStorageContext(optional_ptr<FileOpener> opener,
                                                                                 const string &path,
                                                                                 const AzureParsedUrl &parsed_url) {
@@ -199,25 +238,22 @@ shared_ptr<AzureContextState> AzureStorageFileSystem::GetOrCreateStorageContext(
 
 	shared_ptr<AzureContextState> result;
 	if (azure_context_caching && client_context) {
-		// Cache context key is semantically based on storage_account; if that's unavailable it means we're using
-		// secret manager to deref container -> storage account, which further implies that protocol + container scopes
-		// must uniquely map to a storage account (e.g. az://container1/)
-		auto second =
-		    (parsed_url.storage_account_name.size() > 0 ? parsed_url.storage_account_name : parsed_url.container) + "/";
-		auto context_key = GetContextPrefix() + second;
-
+		string key_path = GetContextKeyPath(opener, path, parsed_url);
 		auto &registered_state = client_context->registered_state;
 
-		result = registered_state->Get<AzureContextState>(context_key);
-		if (!result || !result->IsValid()) {
-			result = CreateStorageContext(opener, path, parsed_url);
-			registered_state->Insert(context_key, result);
+		// Ok, now use account in key, or otherwise skip the cache
+		if (!key_path.empty()) {
+			auto context_key = GetContextPrefix() + key_path;
+			result = registered_state->Get<AzureContextState>(context_key);
+			if (!result || !result->IsValid()) {
+				result = CreateStorageContext(opener, path, parsed_url);
+				registered_state->Insert(context_key, result);
+				return result;
+			}
 		}
-	} else {
-		result = CreateStorageContext(opener, path, parsed_url);
 	}
 
-	return result;
+	return CreateStorageContext(opener, path, parsed_url);
 }
 
 AzureReadOptions AzureStorageFileSystem::ParseAzureReadOptions(optional_ptr<FileOpener> opener) {

--- a/src/include/azure_storage_account_client.hpp
+++ b/src/include/azure_storage_account_client.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "azure_parsed_url.hpp"
-#include "duckdb/common/file_opener.hpp"
+#include <string>
+
 #include <azure/storage/blobs/blob_service_client.hpp>
 #include <azure/storage/files/datalake/datalake_service_client.hpp>
-#include <string>
+
+#include "duckdb/common/file_opener.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+
+#include "azure_parsed_url.hpp"
 
 namespace duckdb {
 
@@ -16,4 +20,5 @@ Azure::Storage::Files::DataLake::DataLakeServiceClient
 ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &path,
                            const AzureParsedUrl &azure_parsed_url);
 
+const SecretMatch LookupSecret(optional_ptr<FileOpener> opener, const std::string &path);
 } // namespace duckdb


### PR DESCRIPTION
fix azure FS client caching (context key)

The context key used to cache Blob and DFS clients was incorrect when using `az://container1/...` forms, and would incorrectly match on e.g.

```
FROM 'az://containerA/foo.csv' UNION FROM `az://containerB/bar.csv`
```

when containerA and containerB are under different storage accounts.

This fixes the context key to use either [a] storage account directly when available, or [b] the container name if not, since that must also uniquely identify the storage acocunt (and thus the client).

This implementation will not cache between different protocol forms, e.g. az://container1 and https://account..../container1 but that's acceptable vs. false hits on the cache.
