### PR TITLE
set User-Agent on Azure http requests, enable 'HTTP' logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(EXTENSION_SOURCES
     src/azure_storage_account_client.cpp
     src/azure_blob_filesystem.cpp
     src/azure_dfs_filesystem.cpp
+    src/http_logging_policy.cpp
     src/http_state_policy.cpp
     src/azure_parsed_url.cpp)
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -34,8 +34,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("azure_http_stats",
 	                          "Include http info from the Azure Storage in the explain analyze statement.",
 	                          LogicalType::BOOLEAN, false);
-	config.AddExtensionOption("azure_http_logging", "Log HTTP requests made by the Azure extension to the DuckDB log.",
-	                          LogicalType::BOOLEAN, false);
+	config.AddExtensionOption(
+	    "azure_http_logging",
+	    "Enable Azure HTTP request logging into the DuckDB HTTP log. When true (default), logging follows "
+	    "DuckDB's HTTP log settings (see enable_logging('HTTP')). Set to false to disable Azure HTTP logging.",
+	    LogicalType::BOOLEAN, true);
 	config.AddExtensionOption(
 	    "azure_http_logging_redact_query_params",
 	    "Semicolon-separated list of URL query parameter names to redact in HTTP logs. Defaults to 'sig'.",

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -43,10 +43,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "azure_http_logging_redact_query_params",
 	    "Semicolon-separated list of URL query parameter names to redact in HTTP logs. Defaults to 'sig'.",
 	    LogicalType::VARCHAR, "sig");
-	config.AddExtensionOption(
-	    "azure_http_logging_redact_headers",
-	    "Semicolon-separated list of request header names to redact in HTTP logs. Defaults to 'Authorization'.",
-	    LogicalType::VARCHAR, "Authorization");
+	config.AddExtensionOption("azure_http_logging_redact_headers",
+	                          "Semicolon-separated list of header names to redact in HTTP logs (both request and "
+	                          "response). Defaults to 'Authorization'.",
+	                          LogicalType::VARCHAR, "Authorization");
 	config.AddExtensionOption("azure_context_caching",
 	                          "Enable/disable the caching of some context when performing queries. "
 	                          "This cache is by default enable, and will for a given connection keep a local context "

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -34,6 +34,17 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("azure_http_stats",
 	                          "Include http info from the Azure Storage in the explain analyze statement.",
 	                          LogicalType::BOOLEAN, false);
+	config.AddExtensionOption("azure_http_logging",
+	                          "Log HTTP requests made by the Azure extension to the DuckDB log.",
+	                          LogicalType::BOOLEAN, false);
+	config.AddExtensionOption(
+	    "azure_http_logging_redact_query_params",
+	    "Semicolon-separated list of URL query parameter names to redact in HTTP logs. Defaults to 'sig'.",
+	    LogicalType::VARCHAR, "sig");
+	config.AddExtensionOption(
+	    "azure_http_logging_redact_headers",
+	    "Semicolon-separated list of request header names to redact in HTTP logs. Defaults to 'Authorization'.",
+	    LogicalType::VARCHAR, "Authorization");
 	config.AddExtensionOption("azure_context_caching",
 	                          "Enable/disable the caching of some context when performing queries. "
 	                          "This cache is by default enable, and will for a given connection keep a local context "

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -34,8 +34,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("azure_http_stats",
 	                          "Include http info from the Azure Storage in the explain analyze statement.",
 	                          LogicalType::BOOLEAN, false);
-	config.AddExtensionOption("azure_http_logging",
-	                          "Log HTTP requests made by the Azure extension to the DuckDB log.",
+	config.AddExtensionOption("azure_http_logging", "Log HTTP requests made by the Azure extension to the DuckDB log.",
 	                          LogicalType::BOOLEAN, false);
 	config.AddExtensionOption(
 	    "azure_http_logging_redact_query_params",

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -5,10 +5,14 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "http_logging_policy.hpp"
 #include "http_state_policy.hpp"
+#include <unordered_set>
 
 #include <azure/core/credentials/token_credential_options.hpp>
 #include <azure/core/http/curl_transport.hpp>
@@ -74,10 +78,14 @@ static std::string AccountUrl(const AzureParsedUrl &azure_parsed_url) {
 
 template <typename T>
 static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                         shared_ptr<AzureHTTPState> http_state) {
+                         shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
 	static_assert(std::is_base_of<Azure::Core::_internal::ClientOptions, T>::value,
 	              "type parameter must be an Azure ClientOptions");
 	T options;
+	auto db = FileOpener::TryGetDatabase(opener);
+	if (db) {
+		options.Telemetry.ApplicationId = StringUtil::Format("%s %s", db->config.UserAgent(), DuckDB::SourceID());
+	}
 	options.Transport = transport_options;
 	if (http_state != nullptr) {
 		// Because we mainly want to have stats on what has been needed and not on
@@ -86,20 +94,65 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 		// increase the input/output but will not be displayed in the EXPLAIN summary.
 		options.PerOperationPolicies.emplace_back(new HttpStatePolicy(std::move(http_state)));
 	}
+	// Add HTTP logging policy (per-retry, so user-agent is already set by the telemetry policy)
+	Value enable_http_logging_value;
+	bool enable_http_logging = false;
+	if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging", enable_http_logging_value)) {
+		enable_http_logging = enable_http_logging_value.GetValue<bool>();
+	}
+	if (enable_http_logging) {
+		auto client_context = FileOpener::TryGetClientContext(opener);
+		if (client_context && client_context->logger) {
+			// Read redaction config options
+			std::unordered_set<std::string> redact_query_params;
+			std::unordered_set<std::string> redact_headers;
+
+			Value redact_query_params_value;
+			if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging_redact_query_params",
+			                                     redact_query_params_value) &&
+			    !redact_query_params_value.IsNull()) {
+				for (auto &param : StringUtil::Split(redact_query_params_value.GetValue<std::string>(), ';')) {
+					auto trimmed = param;
+						StringUtil::Trim(trimmed);
+					if (!trimmed.empty()) {
+						redact_query_params.insert(trimmed);
+					}
+				}
+			}
+
+			Value redact_headers_value;
+			if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging_redact_headers",
+			                                     redact_headers_value) &&
+			    !redact_headers_value.IsNull()) {
+				for (auto &hdr : StringUtil::Split(redact_headers_value.GetValue<std::string>(), ';')) {
+					auto trimmed = hdr;
+						StringUtil::Trim(trimmed);
+						trimmed = StringUtil::Lower(trimmed);
+					if (!trimmed.empty()) {
+						redact_headers.insert(trimmed);
+					}
+				}
+			}
+
+			options.PerRetryPolicies.emplace_back(
+			    new HttpLoggingPolicy(client_context->logger, std::move(redact_query_params),
+			                         std::move(redact_headers)));
+		}
+	}
 	return options;
 }
 
 static Azure::Storage::Blobs::BlobClientOptions
 ToBlobClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                    shared_ptr<AzureHTTPState> http_state) {
-	return ToClientOptions<Azure::Storage::Blobs::BlobClientOptions>(transport_options, std::move(http_state));
+                    shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
+	return ToClientOptions<Azure::Storage::Blobs::BlobClientOptions>(transport_options, std::move(http_state), opener);
 }
 
 static Azure::Storage::Files::DataLake::DataLakeClientOptions
 ToDfsClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                   shared_ptr<AzureHTTPState> http_state) {
+                   shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
 	return ToClientOptions<Azure::Storage::Files::DataLake::DataLakeClientOptions>(transport_options,
-	                                                                               std::move(http_state));
+	                                                                               std::move(http_state), opener);
 }
 
 static Azure::Core::Credentials::TokenCredentialOptions
@@ -346,14 +399,14 @@ GetBlobStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, c
 			                            azure_parsed_url.storage_account_name);
 		}
 
-		auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+		auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 		return Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(connection_string, blob_options);
 	}
 
 	// Default provider (config) with no connection string => public storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, blob_options);
 }
 
@@ -372,7 +425,7 @@ GetDfsStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, co
 			                            azure_parsed_url.storage_account_name);
 		}
 
-		auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+		auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 		return Azure::Storage::Files::DataLake::DataLakeServiceClient::CreateFromConnectionString(connection_string,
 		                                                                                          dfs_options);
 	}
@@ -380,7 +433,7 @@ GetDfsStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, co
 	// Default provider (config) with no connection string => public storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, dfs_options);
 }
 
@@ -394,7 +447,7 @@ GetBlobStorageAccountClientFromCredentialChainProvider(optional_ptr<FileOpener> 
 	// Connect to storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, std::move(credential), blob_options);
 }
 
@@ -408,7 +461,7 @@ GetDfsStorageAccountClientFromCredentialChainProvider(optional_ptr<FileOpener> o
 	// Connect to storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, std::move(credential), dfs_options);
 }
 
@@ -453,7 +506,7 @@ GetBlobStorageAccountClientFromManagedIdentityProvider(optional_ptr<FileOpener> 
 	auto mi_cred = GetManagedIdentityCredential(opener, secret, transport_options);
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, mi_cred, blob_options);
 }
 
@@ -466,7 +519,7 @@ GetDfsStorageAccountClientFromManagedIdentityProvider(optional_ptr<FileOpener> o
 	// Connect to ADLS storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, mi_cred, dfs_options);
 }
 
@@ -479,7 +532,7 @@ GetBlobStorageAccountClientFromServicePrincipalProvider(optional_ptr<FileOpener>
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
 	;
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, token_credential, blob_options);
 }
 
@@ -492,7 +545,7 @@ GetDfsStorageAccountClientFromServicePrincipalProvider(optional_ptr<FileOpener> 
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
 	;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, token_credential, dfs_options);
 }
 
@@ -505,7 +558,7 @@ GetBlobStorageAccountClientFromAccessTokenProvider(optional_ptr<FileOpener> open
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
 	;
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, token_credential, blob_options);
 }
 
@@ -518,7 +571,7 @@ GetDfsStorageAccountClientFromAccessTokenProvider(optional_ptr<FileOpener> opene
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
 	;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, token_credential, dfs_options);
 }
 
@@ -577,7 +630,7 @@ static Azure::Storage::Blobs::BlobServiceClient GetBlobStorageAccountClient(opti
                                                                             const std::string &provided_storage_account,
                                                                             const std::string &provided_endpoint) {
 	auto transport_options = GetTransportOptions(opener);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener));
+	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
 
 	auto connection_string = TryGetCurrentSetting(opener, "azure_storage_connection_string");
 	if (!connection_string.empty() &&
@@ -661,7 +714,7 @@ ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &p
 	// No secret but FQDN has been provided, connect to a public storage account
 	auto transport_options = GetTransportOptions(opener);
 	auto account_url = "https://" + azure_parsed_url.storage_account_name + '.' + azure_parsed_url.endpoint;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener));
+	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, dfs_options);
 }
 

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -76,16 +76,32 @@ static std::string AccountUrl(const AzureParsedUrl &azure_parsed_url) {
 	return AccountUrl(azure_parsed_url.storage_account_name, azure_parsed_url.endpoint);
 }
 
+// Sets the User-Agent header to the DuckDB-generated value, overriding the Azure SDK telemetry header.
+// Registered as a PerRetryPolicy so it runs after the SDK's built-in telemetry policy.
+class UserAgentPolicy : public Azure::Core::Http::Policies::HttpPolicy {
+public:
+	explicit UserAgentPolicy(std::string user_agent_p) : user_agent(std::move(user_agent_p)) {
+	}
+	std::unique_ptr<Azure::Core::Http::RawResponse> Send(Azure::Core::Http::Request &request,
+	                                                     Azure::Core::Http::Policies::NextHttpPolicy next_policy,
+	                                                     Azure::Core::Context const &context) const override {
+		request.SetHeader("User-Agent", user_agent);
+		return next_policy.Send(request, context);
+	}
+	std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override {
+		return std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>(new UserAgentPolicy(user_agent));
+	}
+
+private:
+	std::string user_agent;
+};
+
 template <typename T>
 static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
                          shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
 	static_assert(std::is_base_of<Azure::Core::_internal::ClientOptions, T>::value,
 	              "type parameter must be an Azure ClientOptions");
 	T options;
-	auto db = FileOpener::TryGetDatabase(opener);
-	if (db) {
-		options.Telemetry.ApplicationId = StringUtil::Format("%s %s", db->config.UserAgent(), DuckDB::SourceID());
-	}
 	options.Transport = transport_options;
 	if (http_state != nullptr) {
 		// Because we mainly want to have stats on what has been needed and not on
@@ -94,7 +110,14 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 		// increase the input/output but will not be displayed in the EXPLAIN summary.
 		options.PerOperationPolicies.emplace_back(new HttpStatePolicy(std::move(http_state)));
 	}
-	// Add HTTP logging policy (per-retry, so user-agent is already set by the telemetry policy).
+	// Set DuckDB user-agent (per-retry, overrides user-agent after the SDK's built-in telemetry policy)
+	auto db = FileOpener::TryGetDatabase(opener);
+	if (db) {
+		options.PerRetryPolicies.emplace_back(
+		    new UserAgentPolicy(StringUtil::Format("%s %s", db->config.UserAgent(), DuckDB::SourceID())));
+	}
+
+	// Add HTTP logging policy (per-retry, so user-agent is already set above).
 	// Logging follows DuckDB's HTTP log settings by default; azure_http_logging=false disables it.
 	Value enable_http_logging_value;
 	bool http_logging_enabled = true;

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -96,13 +96,30 @@ private:
 	std::string user_agent;
 };
 
+static shared_ptr<AzureHTTPState> GetHttpState(optional_ptr<FileOpener> opener) {
+	Value value;
+	bool enable_http_stats = false;
+	if (FileOpener::TryGetCurrentSetting(opener, "azure_http_stats", value)) {
+		enable_http_stats = value.GetValue<bool>();
+	}
+
+	shared_ptr<AzureHTTPState> http_state;
+	if (enable_http_stats) {
+		http_state = AzureHTTPState::TryGetState(opener);
+	}
+
+	return http_state;
+}
+
 template <typename T>
 static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                         shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
+                         optional_ptr<FileOpener> opener) {
 	static_assert(std::is_base_of<Azure::Core::_internal::ClientOptions, T>::value,
 	              "type parameter must be an Azure ClientOptions");
 	T options;
 	options.Transport = transport_options;
+
+	auto http_state = GetHttpState(opener);
 	if (http_state != nullptr) {
 		// Because we mainly want to have stats on what has been needed and not on
 		// what has been used on the network, we register the policy on `PerOperationPolicies`
@@ -166,15 +183,14 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 
 static Azure::Storage::Blobs::BlobClientOptions
 ToBlobClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                    shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
-	return ToClientOptions<Azure::Storage::Blobs::BlobClientOptions>(transport_options, std::move(http_state), opener);
+                    optional_ptr<FileOpener> opener) {
+	return ToClientOptions<Azure::Storage::Blobs::BlobClientOptions>(transport_options, opener);
 }
 
 static Azure::Storage::Files::DataLake::DataLakeClientOptions
 ToDfsClientOptions(const Azure::Core::Http::Policies::TransportOptions &transport_options,
-                   shared_ptr<AzureHTTPState> http_state, optional_ptr<FileOpener> opener) {
-	return ToClientOptions<Azure::Storage::Files::DataLake::DataLakeClientOptions>(transport_options,
-	                                                                               std::move(http_state), opener);
+                   optional_ptr<FileOpener> opener) {
+	return ToClientOptions<Azure::Storage::Files::DataLake::DataLakeClientOptions>(transport_options, opener);
 }
 
 static Azure::Core::Credentials::TokenCredentialOptions
@@ -182,21 +198,6 @@ ToTokenCredentialOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 	Azure::Core::Credentials::TokenCredentialOptions options;
 	options.Transport = transport_options;
 	return options;
-}
-
-static shared_ptr<AzureHTTPState> GetHttpState(optional_ptr<FileOpener> opener) {
-	Value value;
-	bool enable_http_stats = false;
-	if (FileOpener::TryGetCurrentSetting(opener, "azure_http_stats", value)) {
-		enable_http_stats = value.GetValue<bool>();
-	}
-
-	shared_ptr<AzureHTTPState> http_state;
-	if (enable_http_stats) {
-		http_state = AzureHTTPState::TryGetState(opener);
-	}
-
-	return http_state;
 }
 
 static std::shared_ptr<Azure::Core::Credentials::TokenCredential>
@@ -421,14 +422,14 @@ GetBlobStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, c
 			                            azure_parsed_url.storage_account_name);
 		}
 
-		auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+		auto blob_options = ToBlobClientOptions(transport_options, opener);
 		return Azure::Storage::Blobs::BlobServiceClient::CreateFromConnectionString(connection_string, blob_options);
 	}
 
 	// Default provider (config) with no connection string => public storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, blob_options);
 }
 
@@ -447,7 +448,7 @@ GetDfsStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, co
 			                            azure_parsed_url.storage_account_name);
 		}
 
-		auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+		auto dfs_options = ToDfsClientOptions(transport_options, opener);
 		return Azure::Storage::Files::DataLake::DataLakeServiceClient::CreateFromConnectionString(connection_string,
 		                                                                                          dfs_options);
 	}
@@ -455,7 +456,7 @@ GetDfsStorageAccountClientFromConfigProvider(optional_ptr<FileOpener> opener, co
 	// Default provider (config) with no connection string => public storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, dfs_options);
 }
 
@@ -469,7 +470,7 @@ GetBlobStorageAccountClientFromCredentialChainProvider(optional_ptr<FileOpener> 
 	// Connect to storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, std::move(credential), blob_options);
 }
 
@@ -483,7 +484,7 @@ GetDfsStorageAccountClientFromCredentialChainProvider(optional_ptr<FileOpener> o
 	// Connect to storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, std::move(credential), dfs_options);
 }
 
@@ -528,7 +529,7 @@ GetBlobStorageAccountClientFromManagedIdentityProvider(optional_ptr<FileOpener> 
 	auto mi_cred = GetManagedIdentityCredential(opener, secret, transport_options);
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, mi_cred, blob_options);
 }
 
@@ -541,7 +542,7 @@ GetDfsStorageAccountClientFromManagedIdentityProvider(optional_ptr<FileOpener> o
 	// Connect to ADLS storage account
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, mi_cred, dfs_options);
 }
 
@@ -554,7 +555,7 @@ GetBlobStorageAccountClientFromServicePrincipalProvider(optional_ptr<FileOpener>
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
 	;
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, token_credential, blob_options);
 }
 
@@ -567,7 +568,7 @@ GetDfsStorageAccountClientFromServicePrincipalProvider(optional_ptr<FileOpener> 
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
 	;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, token_credential, dfs_options);
 }
 
@@ -580,7 +581,7 @@ GetBlobStorageAccountClientFromAccessTokenProvider(optional_ptr<FileOpener> open
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_BLOB_ENDPOINT);
 	;
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 	return Azure::Storage::Blobs::BlobServiceClient(account_url, token_credential, blob_options);
 }
 
@@ -593,7 +594,7 @@ GetDfsStorageAccountClientFromAccessTokenProvider(optional_ptr<FileOpener> opene
 	auto account_url =
 	    azure_parsed_url.is_fully_qualified ? AccountUrl(azure_parsed_url) : AccountUrl(secret, DEFAULT_DFS_ENDPOINT);
 	;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, token_credential, dfs_options);
 }
 
@@ -652,7 +653,7 @@ static Azure::Storage::Blobs::BlobServiceClient GetBlobStorageAccountClient(opti
                                                                             const std::string &provided_storage_account,
                                                                             const std::string &provided_endpoint) {
 	auto transport_options = GetTransportOptions(opener);
-	auto blob_options = ToBlobClientOptions(transport_options, GetHttpState(opener), opener);
+	auto blob_options = ToBlobClientOptions(transport_options, opener);
 
 	auto connection_string = TryGetCurrentSetting(opener, "azure_storage_connection_string");
 	if (!connection_string.empty() &&
@@ -736,7 +737,7 @@ ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &p
 	// No secret but FQDN has been provided, connect to a public storage account
 	auto transport_options = GetTransportOptions(opener);
 	auto account_url = "https://" + azure_parsed_url.storage_account_name + '.' + azure_parsed_url.endpoint;
-	auto dfs_options = ToDfsClientOptions(transport_options, GetHttpState(opener), opener);
+	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, dfs_options);
 }
 

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -94,13 +94,14 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 		// increase the input/output but will not be displayed in the EXPLAIN summary.
 		options.PerOperationPolicies.emplace_back(new HttpStatePolicy(std::move(http_state)));
 	}
-	// Add HTTP logging policy (per-retry, so user-agent is already set by the telemetry policy)
+	// Add HTTP logging policy (per-retry, so user-agent is already set by the telemetry policy).
+	// Logging follows DuckDB's HTTP log settings by default; azure_http_logging=false disables it.
 	Value enable_http_logging_value;
-	bool enable_http_logging = false;
+	bool http_logging_enabled = true;
 	if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging", enable_http_logging_value)) {
-		enable_http_logging = enable_http_logging_value.GetValue<bool>();
+		http_logging_enabled = enable_http_logging_value.GetValue<bool>();
 	}
-	if (enable_http_logging) {
+	if (http_logging_enabled) {
 		auto client_context = FileOpener::TryGetClientContext(opener);
 		if (client_context && client_context->logger) {
 			// Read redaction config options

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -113,7 +113,7 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 			    !redact_query_params_value.IsNull()) {
 				for (auto &param : StringUtil::Split(redact_query_params_value.GetValue<std::string>(), ';')) {
 					auto trimmed = param;
-						StringUtil::Trim(trimmed);
+					StringUtil::Trim(trimmed);
 					if (!trimmed.empty()) {
 						redact_query_params.insert(trimmed);
 					}
@@ -121,22 +121,20 @@ static T ToClientOptions(const Azure::Core::Http::Policies::TransportOptions &tr
 			}
 
 			Value redact_headers_value;
-			if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging_redact_headers",
-			                                     redact_headers_value) &&
+			if (FileOpener::TryGetCurrentSetting(opener, "azure_http_logging_redact_headers", redact_headers_value) &&
 			    !redact_headers_value.IsNull()) {
 				for (auto &hdr : StringUtil::Split(redact_headers_value.GetValue<std::string>(), ';')) {
 					auto trimmed = hdr;
-						StringUtil::Trim(trimmed);
-						trimmed = StringUtil::Lower(trimmed);
+					StringUtil::Trim(trimmed);
+					trimmed = StringUtil::Lower(trimmed);
 					if (!trimmed.empty()) {
 						redact_headers.insert(trimmed);
 					}
 				}
 			}
 
-			options.PerRetryPolicies.emplace_back(
-			    new HttpLoggingPolicy(client_context->logger, std::move(redact_query_params),
-			                         std::move(redact_headers)));
+			options.PerRetryPolicies.emplace_back(new HttpLoggingPolicy(
+			    client_context->logger, std::move(redact_query_params), std::move(redact_headers)));
 		}
 	}
 	return options;

--- a/src/http_logging_policy.cpp
+++ b/src/http_logging_policy.cpp
@@ -1,6 +1,9 @@
 #include "http_logging_policy.hpp"
 #include <azure/core/http/http.hpp>
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "duckdb/logging/logger.hpp"
@@ -79,44 +82,50 @@ static std::string RedactUrlQueryParams(const std::string &url, const std::unord
 	return result;
 }
 
-std::unique_ptr<Azure::Core::Http::RawResponse>
-HttpLoggingPolicy::Send(Azure::Core::Http::Request &request,
-                        Azure::Core::Http::Policies::NextHttpPolicy next_policy,
-                        Azure::Core::Context const &context) const {
-	auto result = next_policy.Send(request, context);
-
-	if (logger && logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
-		// Build request struct
-		auto logged_url = RedactUrlQueryParams(request.GetUrl().GetAbsoluteUrl(), redact_query_params);
-		child_list_t<Value> request_fields = {
-		    {"type", Value(request.GetMethod().ToString())},
-		    {"url", Value(logged_url)},
-		    {"start_time", Value()},
-		    {"duration_ms", Value()},
-		    {"headers", CreateAzureHeadersValue(request.GetHeaders(), redact_headers)},
-		};
-		auto request_value = Value::STRUCT(std::move(request_fields));
-
-		// Build response struct (if available)
-		Value response_value;
-		if (result) {
-			child_list_t<Value> response_fields = {
-			    {"status", Value(std::to_string(static_cast<int>(result->GetStatusCode())))},
-			    {"reason", Value(result->GetReasonPhrase())},
-			    {"headers", CreateAzureHeadersValue(result->GetHeaders(), {})},
-			};
-			response_value = Value::STRUCT(std::move(response_fields));
-		}
-
-		child_list_t<Value> top_fields = {
-		    {"request", std::move(request_value)},
-		    {"response", std::move(response_value)},
-		};
-		auto log_message = Value::STRUCT(std::move(top_fields)).ToString();
-
-		logger->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, log_message);
+// Modeled after httpfs ext LogRequest
+void HttpLoggingPolicy::LogRequest(Azure::Core::Http::Request &request, timestamp_t start_time, timestamp_t end_time,
+                                   const Azure::Core::Http::RawResponse *response) const {
+	if (!logger || !logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
+		return;
 	}
+	auto duration_ms = Timestamp::GetEpochMs(end_time) - Timestamp::GetEpochMs(start_time);
+	auto logged_url = RedactUrlQueryParams(request.GetUrl().GetAbsoluteUrl(), redact_query_params);
+	child_list_t<Value> request_fields = {
+	    {"type", Value(request.GetMethod().ToString())},
+	    {"url", Value(logged_url)},
+	    {"start_time", Value::TIMESTAMPTZ(timestamp_tz_t(start_time))},
+	    {"duration_ms", Value::BIGINT(duration_ms)},
+	    {"headers", CreateAzureHeadersValue(request.GetHeaders(), redact_headers)},
+	};
+	Value resp_value;
+	if (response) {
+		auto duckdb_status = static_cast<HTTPStatusCode>(static_cast<int>(response->GetStatusCode()));
+		child_list_t<Value> response_fields = {
+		    {"status", Value(EnumUtil::ToString(duckdb_status))},
+		    {"reason", Value(response->GetReasonPhrase())},
+		    {"headers", CreateAzureHeadersValue(response->GetHeaders(), {})},
+		};
+		resp_value = Value::STRUCT(std::move(response_fields));
+	}
+	child_list_t<Value> top_fields = {
+	    {"request", Value::STRUCT(std::move(request_fields))},
+	    {"response", std::move(resp_value)},
+	};
+	logger->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, Value::STRUCT(std::move(top_fields)).ToString());
+}
 
+std::unique_ptr<Azure::Core::Http::RawResponse>
+HttpLoggingPolicy::Send(Azure::Core::Http::Request &request, Azure::Core::Http::Policies::NextHttpPolicy next_policy,
+                        Azure::Core::Context const &context) const {
+	auto start_time = Timestamp::GetCurrentTimestamp();
+	std::unique_ptr<Azure::Core::Http::RawResponse> result;
+	try {
+		result = next_policy.Send(request, context);
+	} catch (...) {
+		LogRequest(request, start_time, Timestamp::GetCurrentTimestamp(), nullptr);
+		throw;
+	}
+	LogRequest(request, start_time, Timestamp::GetCurrentTimestamp(), result.get());
 	return result;
 }
 

--- a/src/http_logging_policy.cpp
+++ b/src/http_logging_policy.cpp
@@ -85,7 +85,7 @@ static std::string RedactUrlQueryParams(const std::string &url, const std::unord
 // Modeled after httpfs ext LogRequest
 void HttpLoggingPolicy::LogRequest(Azure::Core::Http::Request &request, timestamp_t start_time, timestamp_t end_time,
                                    const Azure::Core::Http::RawResponse *response) const {
-	if (!logger || !logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
+	if (!logger || !logger->IsThreadSafe() || !logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
 		return;
 	}
 	auto duration_ms = Timestamp::GetEpochMs(end_time) - Timestamp::GetEpochMs(start_time);

--- a/src/http_logging_policy.cpp
+++ b/src/http_logging_policy.cpp
@@ -1,0 +1,128 @@
+#include "http_logging_policy.hpp"
+#include <azure/core/http/http.hpp>
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logger.hpp"
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace duckdb {
+
+HttpLoggingPolicy::HttpLoggingPolicy(shared_ptr<Logger> logger_p, std::unordered_set<std::string> redact_query_params_p,
+                                     std::unordered_set<std::string> redact_headers_p)
+    : logger(std::move(logger_p)), redact_query_params(std::move(redact_query_params_p)),
+      redact_headers(std::move(redact_headers_p)) {
+}
+
+static Value CreateAzureHeadersValue(const Azure::Core::CaseInsensitiveMap &headers,
+                                     const std::unordered_set<std::string> &redact_keys) {
+	vector<Value> keys;
+	vector<Value> values;
+	for (const auto &header : headers) {
+		auto lower_key = StringUtil::Lower(header.first);
+		keys.emplace_back(lower_key);
+		if (redact_keys.count(lower_key) > 0) {
+			values.emplace_back("REDACTED");
+		} else {
+			values.emplace_back(header.second);
+		}
+	}
+	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(keys), std::move(values));
+}
+
+//! Redact the values of the specified query parameters in the given URL string.
+static std::string RedactUrlQueryParams(const std::string &url, const std::unordered_set<std::string> &redact_params) {
+	if (redact_params.empty()) {
+		return url;
+	}
+	auto query_start = url.find('?');
+	if (query_start == std::string::npos) {
+		return url;
+	}
+
+	std::string base = url.substr(0, query_start + 1);
+	std::string query = url.substr(query_start + 1);
+
+	// Parse and rebuild query string with redacted values
+	std::string result = base;
+	bool first = true;
+	size_t pos = 0;
+	while (pos <= query.size()) {
+		auto amp = query.find('&', pos);
+		std::string param = (amp == std::string::npos) ? query.substr(pos) : query.substr(pos, amp - pos);
+		pos = (amp == std::string::npos) ? query.size() + 1 : amp + 1;
+
+		if (param.empty()) {
+			continue;
+		}
+
+		if (!first) {
+			result += '&';
+		}
+		first = false;
+
+		auto eq = param.find('=');
+		if (eq == std::string::npos) {
+			result += param;
+		} else {
+			std::string name = param.substr(0, eq);
+			if (redact_params.count(name) > 0) {
+				result += name + "=REDACTED";
+			} else {
+				result += param;
+			}
+		}
+	}
+	return result;
+}
+
+std::unique_ptr<Azure::Core::Http::RawResponse>
+HttpLoggingPolicy::Send(Azure::Core::Http::Request &request,
+                        Azure::Core::Http::Policies::NextHttpPolicy next_policy,
+                        Azure::Core::Context const &context) const {
+	auto result = next_policy.Send(request, context);
+
+	if (logger && logger->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL)) {
+		// Build request struct
+		auto logged_url = RedactUrlQueryParams(request.GetUrl().GetAbsoluteUrl(), redact_query_params);
+		child_list_t<Value> request_fields = {
+		    {"type", Value(request.GetMethod().ToString())},
+		    {"url", Value(logged_url)},
+		    {"start_time", Value()},
+		    {"duration_ms", Value()},
+		    {"headers", CreateAzureHeadersValue(request.GetHeaders(), redact_headers)},
+		};
+		auto request_value = Value::STRUCT(std::move(request_fields));
+
+		// Build response struct (if available)
+		Value response_value;
+		if (result) {
+			child_list_t<Value> response_fields = {
+			    {"status", Value(std::to_string(static_cast<int>(result->GetStatusCode())))},
+			    {"reason", Value(result->GetReasonPhrase())},
+			    {"headers", CreateAzureHeadersValue(result->GetHeaders(), {})},
+			};
+			response_value = Value::STRUCT(std::move(response_fields));
+		}
+
+		child_list_t<Value> top_fields = {
+		    {"request", std::move(request_value)},
+		    {"response", std::move(response_value)},
+		};
+		auto log_message = Value::STRUCT(std::move(top_fields)).ToString();
+
+		logger->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, log_message);
+	}
+
+	return result;
+}
+
+std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> HttpLoggingPolicy::Clone() const {
+	return std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy>(
+	    new HttpLoggingPolicy(logger, redact_query_params, redact_headers));
+}
+
+} // namespace duckdb

--- a/src/http_logging_policy.cpp
+++ b/src/http_logging_policy.cpp
@@ -103,7 +103,7 @@ void HttpLoggingPolicy::LogRequest(Azure::Core::Http::Request &request, timestam
 		child_list_t<Value> response_fields = {
 		    {"status", Value(EnumUtil::ToString(duckdb_status))},
 		    {"reason", Value(response->GetReasonPhrase())},
-		    {"headers", CreateAzureHeadersValue(response->GetHeaders(), {})},
+		    {"headers", CreateAzureHeadersValue(response->GetHeaders(), redact_headers)},
 		};
 		resp_value = Value::STRUCT(std::move(response_fields));
 	}

--- a/src/include/http_logging_policy.hpp
+++ b/src/include/http_logging_policy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 #include <azure/core/context.hpp>
 #include <azure/core/http/http.hpp>
 #include <azure/core/http/policies/policy.hpp>
@@ -25,6 +26,9 @@ public:
 	std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override;
 
 private:
+	void LogRequest(Azure::Core::Http::Request &request, timestamp_t start_time, timestamp_t end_time,
+	                const Azure::Core::Http::RawResponse *response) const;
+
 	shared_ptr<Logger> logger;
 	std::unordered_set<std::string> redact_query_params;
 	std::unordered_set<std::string> redact_headers;

--- a/src/include/http_logging_policy.hpp
+++ b/src/include/http_logging_policy.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "duckdb/common/shared_ptr.hpp"
+#include <azure/core/context.hpp>
+#include <azure/core/http/http.hpp>
+#include <azure/core/http/policies/policy.hpp>
+#include <azure/core/http/raw_response.hpp>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+namespace duckdb {
+
+class Logger;
+
+class HttpLoggingPolicy : public Azure::Core::Http::Policies::HttpPolicy {
+public:
+	HttpLoggingPolicy(shared_ptr<Logger> logger, std::unordered_set<std::string> redact_query_params,
+	                  std::unordered_set<std::string> redact_headers);
+
+	std::unique_ptr<Azure::Core::Http::RawResponse> Send(Azure::Core::Http::Request &request,
+	                                                     Azure::Core::Http::Policies::NextHttpPolicy next_policy,
+	                                                     Azure::Core::Context const &context) const override;
+
+	std::unique_ptr<Azure::Core::Http::Policies::HttpPolicy> Clone() const override;
+
+private:
+	shared_ptr<Logger> logger;
+	std::unordered_set<std::string> redact_query_params;
+	std::unordered_set<std::string> redact_headers;
+};
+
+} // namespace duckdb

--- a/test/sql/http.test
+++ b/test/sql/http.test
@@ -1,5 +1,5 @@
-# name: test/sql/user_agent.test
-# description: Confirm that the User-Agent header is set with the standard duckdb prefix
+# name: test/sql/http.test
+# description: Test HTTP logging: user-agent format, timing fields, and response status format
 # group: [sql]
 
 require azure
@@ -22,6 +22,22 @@ query I
 SELECT count(*) > 0
 FROM duckdb_logs_parsed('HTTP')
 WHERE starts_with(request.headers['user-agent'], 'duckdb');
+----
+true
+
+# Verify start_time and duration_ms filled
+query I
+SELECT count(*) > 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.start_time IS NOT NULL AND request.duration_ms >= 0;
+----
+true
+
+# Confirm statuses use DuckDB HTTP log style (e.g. 'OK_200', not '200')
+query I
+SELECT count(*) = count(*) FILTER (WHERE contains(response.status, '_'))
+FROM duckdb_logs_parsed('HTTP')
+WHERE response IS NOT NULL;
 ----
 true
 

--- a/test/sql/http.test
+++ b/test/sql/http.test
@@ -13,9 +13,6 @@ statement ok
 CALL enable_logging('HTTP');
 
 statement ok
-SET azure_http_logging = true;
-
-statement ok
 SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
 
 query I

--- a/test/sql/http_log_redaction.test
+++ b/test/sql/http_log_redaction.test
@@ -1,0 +1,122 @@
+# name: test/sql/http_log_redaction.test
+# description: Test that sensitive query parameters and headers are redacted in HTTP logs by default
+# group: [sql]
+
+require azure
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+statement ok
+SET azure_storage_connection_string = '${AZURE_STORAGE_CONNECTION_STRING}';
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+SET azure_http_logging = true;
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+# Verify that at least one HTTP log entry was recorded
+query I
+SELECT count(*) > 0
+FROM duckdb_logs_parsed('HTTP');
+----
+true
+
+# Verify that 'sig' query parameter is redacted by default:
+# If 'sig' appears in the URL it must be redacted; some auth types don't use 'sig' at all, which is also fine.
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE contains(request.url, 'sig=') AND NOT contains(request.url, 'sig=REDACTED');
+----
+true
+
+# Verify that 'Authorization' header is redacted by default:
+# If present in logs, its value must be REDACTED; some auth types don't send this header at all.
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['authorization'] IS NOT NULL
+  AND request.headers['authorization'] != 'REDACTED';
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Test custom redaction: redact 'x-ms-date' header
+statement ok
+SET azure_http_logging_redact_headers = 'x-ms-date';
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+# x-ms-date header should be redacted
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['x-ms-date'] IS NOT NULL
+  AND request.headers['x-ms-date'] != 'REDACTED';
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Test multiple headers in config (semicolon-separated): redact both 'x-ms-date' and 'x-ms-version'
+statement ok
+SET azure_http_logging_redact_headers = 'x-ms-date;x-ms-version';
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+# x-ms-date must be redacted if present
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['x-ms-date'] IS NOT NULL
+  AND request.headers['x-ms-date'] != 'REDACTED';
+----
+true
+
+# x-ms-version must be redacted if present
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.headers['x-ms-version'] IS NOT NULL
+  AND request.headers['x-ms-version'] != 'REDACTED';
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Test that redaction can be disabled by setting empty list
+statement ok
+SET azure_http_logging_redact_query_params = '';
+
+statement ok
+SET azure_http_logging_redact_headers = '';
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+# With no redaction, logs should still contain entries
+query I
+SELECT count(*) > 0
+FROM duckdb_logs_parsed('HTTP');
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs();
+
+# Reset to defaults
+statement ok
+SET azure_http_logging_redact_query_params = 'sig';
+
+statement ok
+SET azure_http_logging_redact_headers = 'Authorization';

--- a/test/sql/http_log_redaction.test
+++ b/test/sql/http_log_redaction.test
@@ -82,12 +82,21 @@ WHERE request.headers['x-ms-date'] IS NOT NULL
 ----
 true
 
-# x-ms-version must be redacted if present
+# x-ms-version must be redacted in request headers if present
 query I
 SELECT count(*) = 0
 FROM duckdb_logs_parsed('HTTP')
 WHERE request.headers['x-ms-version'] IS NOT NULL
   AND request.headers['x-ms-version'] != 'REDACTED';
+----
+true
+
+# x-ms-version must also be redacted in response headers if present (redaction applies to both sides)
+query I
+SELECT count(*) = 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE response.headers['x-ms-version'] IS NOT NULL
+  AND response.headers['x-ms-version'] != 'REDACTED';
 ----
 true
 

--- a/test/sql/http_log_redaction.test
+++ b/test/sql/http_log_redaction.test
@@ -13,9 +13,6 @@ statement ok
 CALL enable_logging('HTTP');
 
 statement ok
-SET azure_http_logging = true;
-
-statement ok
 SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
 
 # Verify that at least one HTTP log entry was recorded

--- a/test/sql/user_agent.test
+++ b/test/sql/user_agent.test
@@ -1,0 +1,40 @@
+# name: test/sql/user_agent.test
+# description: Confirm that the User-Agent header is set with the standard duckdb prefix
+# group: [sql]
+
+require azure
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+statement ok
+SET azure_storage_connection_string = '${AZURE_STORAGE_CONNECTION_STRING}';
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+SET azure_http_logging = true;
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+query I
+SELECT count(*) > 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE starts_with(request.headers['user-agent'], 'duckdb');
+----
+true
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+SET azure_http_logging = false;
+
+statement ok
+SELECT sum(l_orderkey) FROM 'az://testing-private/l.csv';
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('HTTP');
+----
+0


### PR DESCRIPTION
- set User-Agent in Azure http calls for meaningful user agent telemetry (now a la `duckdb/v1.5.1(osx_arm64) cli 7dbb2e646f`)
- hooks into standard logging also provided `CALL enable_logging('HTTP', level='trace');`
  - include redaction of both specified headers and query params;
  - see options `azure_http_logging_redact_query_params` and `azure_http_logging_redact_headers`
- azure HTTP logging can be specifically disabled via `SET azure_http_logging = false`

Produces output a la:

```
memory D SELECT request.type, request.headers FROM duckdb_logs_parsed('HTTP');
┌─────────┬─────────────────────────────────────────────────────────────────────────────────────────┐
│  type   │                                         headers                                         │
│ varchar │                                  map(varchar, varchar)                                  │
├─────────┼─────────────────────────────────────────────────────────────────────────────────────────┤
│ HEAD    │ {User-Agent='duckdb/v1.5.1(osx_arm64) cli 7dbb2e646f'}                                  │
│ GET     │ {User-Agent='duckdb/v1.5.1(osx_arm64) cli 7dbb2e646f', Range='bytes=0-1048575'}         │
...
```
