### PR TITLE
Azure metadata cache hookup and Azure integration test updates

### DIFF
--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -355,11 +355,7 @@ bool AzureBlobStorageFileSystem::DirectoryExists(const string &dirname, optional
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-	if (handle != nullptr) {
-		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
-		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
-	}
-	return false;
+	return handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR;
 }
 
 void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -155,7 +155,9 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 	auto first_wildcard_pos = azure_url.path.find_first_of("*[\\");
 	if (first_wildcard_pos == string::npos) {
 		vector<OpenFileInfo> rv;
-		if (FileExists(path, opener)) {
+		auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
+		// Returning directories here suppresses DuckDB's fallback auto-glob path for multi-file readers.
+		if (handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR) {
 			rv.emplace_back(path);
 		}
 		return rv;
@@ -355,7 +357,11 @@ bool AzureBlobStorageFileSystem::DirectoryExists(const string &dirname, optional
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-	return handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR;
+	if (handle != nullptr) {
+		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
+		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
+	}
+	return false;
 }
 
 void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -199,7 +199,12 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 				OpenFileInfo info(result_full_url);
 				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 				auto &options = info.extended_info->options;
-				options.emplace("type", Value("file"));
+				// Flat Blob listing on HNS accounts can surface directories as zero-length Blob entries.
+				// Only stamp a file type when the item is clearly a non-empty file so we can seed the cache
+				// without misclassifying folders.
+				if (key.BlobSize > 0) {
+					options.emplace("type", Value("file"));
+				}
 				options.emplace("file_size", Value::BIGINT(key.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(key.Details.LastModified)));
 				result.push_back(info);

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -74,8 +74,10 @@ AzureBlobContextState::GetBlobContainerClient(const std::string &blobContainerNa
 //////// AzureBlobStorageFileHandle ////////
 AzureBlobStorageFileHandle::AzureBlobStorageFileHandle(AzureBlobStorageFileSystem &fs, const OpenFileInfo &info,
                                                        FileOpenFlags flags, const AzureReadOptions &read_options,
+                                                       optional_ptr<AzureMetadataCache> metadata_cache,
                                                        Azure::Storage::Blobs::BlockBlobClient blob_client)
-    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, read_options), blob_client(std::move(blob_client)) {
+    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, read_options, metadata_cache),
+      blob_client(std::move(blob_client)) {
 }
 
 void AzureBlobStorageFileHandle::Sync() {
@@ -123,11 +125,14 @@ unique_ptr<AzureFileHandle> AzureBlobStorageFileSystem::CreateHandle(const OpenF
 
 	auto parsed_url = ParseUrl(info.path);
 	auto storage_context = GetOrCreateStorageContext(opener, info.path, parsed_url);
+	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+		InvalidateMetadata(opener, info.path);
+	}
 	auto container = storage_context->As<AzureBlobContextState>().GetBlobContainerClient(parsed_url.container);
 	auto blob_client = container.GetBlockBlobClient(parsed_url.path);
 
 	auto handle = make_uniq<AzureBlobStorageFileHandle>(*this, info, flags, storage_context->read_options,
-	                                                    std::move(blob_client));
+	                                                    GetMetadataCache(opener), std::move(blob_client));
 	if (!handle->PostConstruct()) {
 		return nullptr;
 	}
@@ -192,6 +197,7 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 				OpenFileInfo info(result_full_url);
 				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 				auto &options = info.extended_info->options;
+				options.emplace("type", Value("file"));
 				options.emplace("file_size", Value::BIGINT(key.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(key.Details.LastModified)));
 				result.push_back(info);
@@ -282,11 +288,7 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, don't create
 
 	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod) {
-		afh.is_remote_loaded = true; // always set loaded
-		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
-		afh.length = is_dir ? 0 : length;
-		afh.last_modified = last_mod;
-		afh.file_offset = 0; // always reset offset state
+		afh.SetFileInfo(is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR, length, last_mod);
 	};
 
 	auto create_file = [&]() {
@@ -367,6 +369,7 @@ void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr
 	auto blob_client = container.GetBlockBlobClient(url.path);
 	try {
 		blob_client.Delete();
+		InvalidateMetadata(opener, filename);
 	} catch (Azure::Storage::StorageException &e) {
 		throw IOException("AzureBlobStorageFileSystem Delete of %s failed with %s Reason Phrase: %s", filename,
 		                  e.ErrorCode, e.ReasonPhrase);
@@ -378,7 +381,11 @@ bool AzureBlobStorageFileSystem::TryRemoveFile(const string &filename, optional_
 	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
 	auto container = storage_context->As<AzureBlobContextState>().GetBlobContainerClient(url.container);
 	auto blob_client = container.GetBlockBlobClient(url.path);
-	return blob_client.DeleteIfExists().Value.Deleted;
+	auto removed = blob_client.DeleteIfExists().Value.Deleted;
+	if (removed) {
+		InvalidateMetadata(opener, filename);
+	}
+	return removed;
 }
 
 void AzureBlobStorageFileSystem::ReadRange(AzureFileHandle &handle, idx_t file_offset, char *buffer_out,

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -380,11 +380,7 @@ bool AzureBlobStorageFileSystem::DirectoryExists(const string &dirname, optional
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-	if (handle != nullptr) {
-		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
-		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
-	}
-	return false;
+	return handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR;
 }
 
 void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -170,7 +170,9 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 	auto first_wildcard_pos = azure_url.path.find_first_of("*[\\");
 	if (first_wildcard_pos == string::npos) {
 		vector<OpenFileInfo> rv;
-		if (FileExists(path, opener)) {
+		auto handle = OpenFile(path, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
+		// Returning directories here suppresses DuckDB's fallback auto-glob path for multi-file readers.
+		if (handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR) {
 			rv.emplace_back(path);
 		}
 		return rv;
@@ -380,7 +382,11 @@ bool AzureBlobStorageFileSystem::DirectoryExists(const string &dirname, optional
 
 bool AzureBlobStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
 	auto handle = OpenFile(filename, FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS, opener);
-	return handle && handle->Cast<AzureBlobStorageFileHandle>().GetType() == FileType::FILE_TYPE_REGULAR;
+	if (handle != nullptr) {
+		auto &sfh = handle->Cast<AzureBlobStorageFileHandle>();
+		return sfh.length >= 0; // aka return true; -- avoid optimizers and shenanigans -- deref handle to be sure
+	}
+	return false;
 }
 
 void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -214,7 +214,12 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 				OpenFileInfo info(result_full_url);
 				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 				auto &options = info.extended_info->options;
-				options.emplace("type", Value("file"));
+				// Flat Blob listing on HNS accounts can surface directories as zero-length Blob entries.
+				// Only stamp a file type when the item is clearly a non-empty file so we can seed the cache
+				// without misclassifying folders.
+				if (key.BlobSize > 0) {
+					options.emplace("type", Value("file"));
+				}
 				options.emplace("file_size", Value::BIGINT(key.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(key.Details.LastModified)));
 				auto etag = StripETagQuotes(key.Details.ETag.ToString());

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -75,8 +75,10 @@ AzureBlobContextState::GetBlobContainerClient(const std::string &blobContainerNa
 //////// AzureBlobStorageFileHandle ////////
 AzureBlobStorageFileHandle::AzureBlobStorageFileHandle(AzureBlobStorageFileSystem &fs, const OpenFileInfo &info,
                                                        FileOpenFlags flags, const AzureOptions &opts,
+                                                       optional_ptr<AzureMetadataCache> metadata_cache,
                                                        Azure::Storage::Blobs::BlockBlobClient blob_client)
-    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, opts), blob_client(std::move(blob_client)) {
+    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, opts, metadata_cache),
+      blob_client(std::move(blob_client)) {
 }
 
 void AzureBlobStorageFileHandle::StageWriteBuffer() {
@@ -138,11 +140,14 @@ unique_ptr<AzureFileHandle> AzureBlobStorageFileSystem::CreateHandle(const OpenF
 
 	auto parsed_url = ParseUrl(info.path);
 	auto storage_context = GetOrCreateStorageContext(opener, info.path, parsed_url);
+	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+		InvalidateMetadata(opener, info.path);
+	}
 	auto container = storage_context->As<AzureBlobContextState>().GetBlobContainerClient(parsed_url.container);
 	auto blob_client = container.GetBlockBlobClient(parsed_url.path);
 
-	auto handle =
-	    make_uniq<AzureBlobStorageFileHandle>(*this, info, flags, storage_context->options, std::move(blob_client));
+	auto handle = make_uniq<AzureBlobStorageFileHandle>(*this, info, flags, storage_context->options,
+	                                                    GetMetadataCache(opener), std::move(blob_client));
 	if (!handle->PostConstruct()) {
 		return nullptr;
 	}
@@ -207,6 +212,7 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 				OpenFileInfo info(result_full_url);
 				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 				auto &options = info.extended_info->options;
+				options.emplace("type", Value("file"));
 				options.emplace("file_size", Value::BIGINT(key.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(key.Details.LastModified)));
 				auto etag = StripETagQuotes(key.Details.ETag.ToString());
@@ -305,12 +311,8 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, don't create
 
 	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod, const string &etag) {
-		afh.is_remote_loaded = true; // always set loaded
-		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
-		afh.length = is_dir ? 0 : length;
-		afh.last_modified = last_mod;
-		afh.etag = StripETagQuotes(etag);
-		afh.file_offset = 0; // always reset offset state
+		afh.SetFileInfo(is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR, length, last_mod,
+		                StripETagQuotes(etag));
 	};
 
 	auto create_file = [&]() {
@@ -392,6 +394,7 @@ void AzureBlobStorageFileSystem::RemoveFile(const string &filename, optional_ptr
 	auto blob_client = container.GetBlockBlobClient(url.path);
 	try {
 		blob_client.Delete();
+		InvalidateMetadata(opener, filename);
 	} catch (Azure::Storage::StorageException &e) {
 		throw IOException("AzureBlobStorageFileSystem Delete of %s failed with %s Reason Phrase: %s", filename,
 		                  e.ErrorCode, e.ReasonPhrase);
@@ -403,7 +406,11 @@ bool AzureBlobStorageFileSystem::TryRemoveFile(const string &filename, optional_
 	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
 	auto container = storage_context->As<AzureBlobContextState>().GetBlobContainerClient(url.container);
 	auto blob_client = container.GetBlockBlobClient(url.path);
-	return blob_client.DeleteIfExists().Value.Deleted;
+	auto removed = blob_client.DeleteIfExists().Value.Deleted;
+	if (removed) {
+		InvalidateMetadata(opener, filename);
+	}
+	return removed;
 }
 
 void AzureBlobStorageFileSystem::ReadRange(AzureFileHandle &handle, idx_t file_offset, char *buffer_out,

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -72,6 +72,7 @@ static void Walk(const Azure::Storage::Files::DataLake::DataLakeFileSystemClient
 					OpenFileInfo info(elt.Name);
 					info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 					auto &options = info.extended_info->options;
+					options.emplace("type", Value("file"));
 					options.emplace("file_size", Value::BIGINT(elt.FileSize));
 					options.emplace("last_modified",
 					                Value::TIMESTAMP(AzureStorageFileSystem::ToTimestamp(elt.LastModified)));
@@ -102,8 +103,10 @@ AzureDfsContextState::GetDfsFileSystemClient(const std::string &file_system_name
 //////// AzureDfsContextState ////////
 AzureDfsStorageFileHandle::AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info,
                                                      FileOpenFlags flags, const AzureReadOptions &read_options,
+                                                     optional_ptr<AzureMetadataCache> metadata_cache,
                                                      Azure::Storage::Files::DataLake::DataLakeFileClient client)
-    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, read_options), file_client(std::move(client)) {
+    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, read_options, metadata_cache),
+      file_client(std::move(client)) {
 }
 
 void AzureDfsStorageFileHandle::Sync(bool close) {
@@ -137,9 +140,13 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 
 	auto parsed_url = ParseUrl(info.path);
 	auto storage_context = GetOrCreateStorageContext(opener, info.path, parsed_url);
+	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+		InvalidateMetadata(opener, info.path);
+	}
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(parsed_url.container);
 
 	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->read_options,
+	                                                   GetMetadataCache(opener),
 	                                                   file_system_client.GetFileClient(parsed_url.path));
 	if (!handle->PostConstruct()) {
 		return nullptr;
@@ -164,6 +171,7 @@ void AzureDfsStorageFileSystem::CreateDirectory(const string &dirname, optional_
 	auto storage_context = GetOrCreateStorageContext(opener, dirname, dir_url);
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(dir_url.container);
 	file_system_client.GetDirectoryClient(dir_url.path).Create();
+	InvalidateMetadata(opener, dirname);
 }
 
 bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
@@ -178,6 +186,7 @@ void AzureDfsStorageFileSystem::RemoveFile(const string &filename, optional_ptr<
 	auto file_client = file_system_client.GetFileClient(url.path);
 	try {
 		file_client.Delete();
+		InvalidateMetadata(opener, filename);
 	} catch (Azure::Storage::StorageException &e) {
 		throw IOException("AzureDfsStorageFileSystem Delete of %s failed with %s Reason Phrase: %s", filename,
 		                  e.ErrorCode, e.ReasonPhrase);
@@ -189,7 +198,11 @@ bool AzureDfsStorageFileSystem::TryRemoveFile(const string &filename, optional_p
 	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(url.container);
 	auto file_client = file_system_client.GetFileClient(url.path);
-	return file_client.DeleteIfExists().Value.Deleted;
+	auto removed = file_client.DeleteIfExists().Value.Deleted;
+	if (removed) {
+		InvalidateMetadata(opener, filename);
+	}
+	return removed;
 }
 
 vector<OpenFileInfo> AzureDfsStorageFileSystem::Glob(const string &path, FileOpener *opener) {
@@ -292,11 +305,7 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, don't create
 
 	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod) {
-		afh.is_remote_loaded = true; // always set loaded
-		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
-		afh.length = is_dir ? 0 : length;
-		afh.last_modified = last_mod;
-		afh.file_offset = 0; // always reset offset state
+		afh.SetFileInfo(is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR, length, last_mod);
 	};
 
 	auto create_file = [&]() {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -73,6 +73,7 @@ static void Walk(const Azure::Storage::Files::DataLake::DataLakeFileSystemClient
 					OpenFileInfo info(elt.Name);
 					info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 					auto &options = info.extended_info->options;
+					options.emplace("type", Value("file"));
 					options.emplace("file_size", Value::BIGINT(elt.FileSize));
 					options.emplace("last_modified",
 					                Value::TIMESTAMP(AzureStorageFileSystem::ToTimestamp(elt.LastModified)));
@@ -107,8 +108,10 @@ AzureDfsContextState::GetDfsFileSystemClient(const std::string &file_system_name
 //////// AzureDfsContextState ////////
 AzureDfsStorageFileHandle::AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info,
                                                      FileOpenFlags flags, const AzureOptions &options,
+                                                     optional_ptr<AzureMetadataCache> metadata_cache,
                                                      Azure::Storage::Files::DataLake::DataLakeFileClient client)
-    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, options), file_client(std::move(client)) {
+    : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, options, metadata_cache),
+      file_client(std::move(client)) {
 }
 
 void AzureDfsStorageFileHandle::StageWriteBuffer() {
@@ -165,6 +168,9 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 
 	auto parsed_url = ParseUrl(info.path);
 	auto storage_context = GetOrCreateStorageContext(opener, info.path, parsed_url);
+	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+		InvalidateMetadata(opener, info.path);
+	}
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(parsed_url.container);
 
 	// A trailing '/' is only a directory hint, not part of the resource name. Some DFS endpoints (e.g. OneLake)
@@ -175,6 +181,7 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 	}
 
 	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options,
+	                                                   GetMetadataCache(opener),
 	                                                   file_system_client.GetFileClient(file_path));
 	if (!handle->PostConstruct()) {
 		return nullptr;
@@ -199,6 +206,7 @@ void AzureDfsStorageFileSystem::CreateDirectory(const string &dirname, optional_
 	auto storage_context = GetOrCreateStorageContext(opener, dirname, dir_url);
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(dir_url.container);
 	file_system_client.GetDirectoryClient(dir_url.path).Create();
+	InvalidateMetadata(opener, dirname);
 }
 
 bool AzureDfsStorageFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
@@ -213,6 +221,7 @@ void AzureDfsStorageFileSystem::RemoveFile(const string &filename, optional_ptr<
 	auto file_client = file_system_client.GetFileClient(url.path);
 	try {
 		file_client.Delete();
+		InvalidateMetadata(opener, filename);
 	} catch (Azure::Storage::StorageException &e) {
 		throw IOException("AzureDfsStorageFileSystem Delete of %s failed with %s Reason Phrase: %s", filename,
 		                  e.ErrorCode, e.ReasonPhrase);
@@ -224,7 +233,11 @@ bool AzureDfsStorageFileSystem::TryRemoveFile(const string &filename, optional_p
 	auto storage_context = GetOrCreateStorageContext(opener, filename, url);
 	auto file_system_client = storage_context->As<AzureDfsContextState>().GetDfsFileSystemClient(url.container);
 	auto file_client = file_system_client.GetFileClient(url.path);
-	return file_client.DeleteIfExists().Value.Deleted;
+	auto removed = file_client.DeleteIfExists().Value.Deleted;
+	if (removed) {
+		InvalidateMetadata(opener, filename);
+	}
+	return removed;
 }
 
 vector<OpenFileInfo> AzureDfsStorageFileSystem::Glob(const string &path, FileOpener *opener) {
@@ -333,12 +346,8 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, don't create
 
 	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod, const string &etag) {
-		afh.is_remote_loaded = true; // always set loaded
-		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
-		afh.length = is_dir ? 0 : length;
-		afh.last_modified = last_mod;
-		afh.etag = StripETagQuotes(etag);
-		afh.file_offset = 0; // always reset offset state
+		afh.SetFileInfo(is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR, length, last_mod,
+		                StripETagQuotes(etag));
 	};
 
 	auto create_file = [&]() {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -180,9 +180,9 @@ unique_ptr<AzureFileHandle> AzureDfsStorageFileSystem::CreateHandle(const OpenFi
 		file_path.pop_back();
 	}
 
-	auto handle = make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options,
-	                                                   GetMetadataCache(opener),
-	                                                   file_system_client.GetFileClient(file_path));
+	auto handle =
+	    make_uniq<AzureDfsStorageFileHandle>(*this, info, flags, storage_context->options, GetMetadataCache(opener),
+	                                         file_system_client.GetFileClient(file_path));
 	if (!handle->PostConstruct()) {
 		return nullptr;
 	}

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -24,39 +24,151 @@ void AzureContextState::QueryEnd() {
 	is_valid = false;
 }
 
+static string GetFileType(const Value &value) {
+	auto type = value.ToString();
+	if (!type.empty() && type.front() == '\'' && type.back() == '\'' && type.size() >= 2) {
+		type = type.substr(1, type.size() - 2);
+	}
+	return type;
+}
+
 AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-                                 FileType file_type, const AzureReadOptions &read_options)
+                                 FileType file_type, const AzureReadOptions &read_options,
+                                 optional_ptr<AzureMetadataCache> metadata_cache_p)
     : FileHandle(fs, info.path, flags), flags(flags),
       // File info
       is_remote_loaded(false), file_type(file_type), length(0), last_modified(0),
       // Read info
       buffer_available(0), buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0),
       // Options
-      read_options(read_options) {
+      read_options(read_options), metadata_cache(metadata_cache_p) {
 	if (!flags.RequireParallelAccess() && !flags.DirectIO()) {
 		read_buffer = duckdb::unique_ptr<data_t[]>(new data_t[read_options.buffer_size]);
 	}
 
 	// Set metadata of file when available, it avoids to invoke to the storage to get them.
+	bool has_file_type = file_type != FileType::FILE_TYPE_INVALID;
+	bool has_length = false;
+	bool has_last_modified = false;
 	if (info.extended_info) {
+		auto type_entry = info.extended_info->options.find("type");
+		if (type_entry != info.extended_info->options.end()) {
+			auto type = GetFileType(type_entry->second);
+			if (type == "directory") {
+				file_type = FileType::FILE_TYPE_DIR;
+				has_file_type = true;
+			} else if (type == "file") {
+				file_type = FileType::FILE_TYPE_REGULAR;
+				has_file_type = true;
+			}
+		}
 		auto entry1 = info.extended_info->options.find("file_size");
 		if (entry1 != info.extended_info->options.end()) {
 			length = entry1->second.GetValue<uint64_t>();
+			has_length = true;
 		}
 		auto entry2 = info.extended_info->options.find("last_modified");
 		if (entry2 != info.extended_info->options.end()) {
 			last_modified = entry2->second.GetValue<timestamp_t>();
+			has_last_modified = true;
 		}
 	}
+	if (has_file_type && has_last_modified && (file_type == FileType::FILE_TYPE_DIR || has_length)) {
+		SetFileInfo(file_type, length, last_modified);
+	}
+}
+
+void AzureFileHandle::SetFileInfo(FileType file_type_p, idx_t length_p, timestamp_t last_modified_p) {
+	is_remote_loaded = true;
+	file_type = file_type_p;
+	length = file_type_p == FileType::FILE_TYPE_DIR ? 0 : length_p;
+	last_modified = last_modified_p;
+	file_offset = 0;
 }
 
 bool AzureFileHandle::PostConstruct() {
 	return static_cast<AzureStorageFileSystem &>(file_system).LoadFileInfo(*this);
 }
 
+static bool CanUseMetadataCache(const AzureFileHandle &handle) {
+	return handle.metadata_cache && !handle.flags.OpenForWriting() && !handle.flags.OpenForAppending() &&
+	       !handle.flags.ExclusiveCreate();
+}
+
+static AzureFileInfo GetCacheEntry(const AzureFileHandle &handle) {
+	AzureFileInfo info;
+	info.file_type = handle.file_type;
+	info.length = handle.length;
+	info.last_modified = handle.last_modified;
+	return info;
+}
+
+bool AzureStorageFileSystem::ParseAzureMetadataCacheEnabled(optional_ptr<FileOpener> opener) {
+	Value metadata_cache_val;
+	if (FileOpener::TryGetCurrentSetting(opener, "enable_http_metadata_cache", metadata_cache_val) &&
+	    !metadata_cache_val.IsNull()) {
+		return metadata_cache_val.GetValue<bool>();
+	}
+	return false;
+}
+
+optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetGlobalMetadataCache() {
+	lock_guard<mutex> lock(global_cache_lock);
+	if (!global_metadata_cache) {
+		global_metadata_cache = make_uniq<AzureMetadataCache>(false, true);
+	}
+	return global_metadata_cache.get();
+}
+
+optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetMetadataCache(optional_ptr<FileOpener> opener) {
+	auto db = FileOpener::TryGetDatabase(opener);
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (!db) {
+		return nullptr;
+	}
+	if (ParseAzureMetadataCacheEnabled(opener)) {
+		return GetGlobalMetadataCache();
+	}
+	if (client_context) {
+		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true, false)
+		    .get();
+	}
+	return nullptr;
+}
+
+void AzureStorageFileSystem::InvalidateMetadata(optional_ptr<FileOpener> opener, const string &path) {
+	auto metadata_cache = GetMetadataCache(opener);
+	if (metadata_cache) {
+		metadata_cache->Erase(path);
+	}
+}
+
 bool AzureStorageFileSystem::LoadFileInfo(AzureFileHandle &handle) {
 	try {
+		if (handle.IsRemoteLoaded()) {
+			if (CanUseMetadataCache(handle)) {
+				handle.metadata_cache->Insert(handle.path, GetCacheEntry(handle));
+			}
+			if (handle.flags.ReturnNullIfExists()) {
+				return false;
+			}
+			return true;
+		}
+		if (CanUseMetadataCache(handle)) {
+			AzureFileInfo cached_info;
+			if (handle.metadata_cache->Find(handle.path, cached_info)) {
+				handle.SetFileInfo(cached_info.file_type, cached_info.length, cached_info.last_modified);
+				if (handle.flags.ReturnNullIfExists()) {
+					return false;
+				}
+				return true;
+			}
+		}
+
 		LoadRemoteFileInfo(handle);
+		if (CanUseMetadataCache(handle)) {
+			handle.metadata_cache->Insert(handle.path, GetCacheEntry(handle));
+		}
 		if (handle.flags.ReturnNullIfExists()) {
 			return false;
 		}

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -115,7 +115,7 @@ bool AzureStorageFileSystem::ParseAzureMetadataCacheEnabled(optional_ptr<FileOpe
 optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetGlobalMetadataCache() {
 	lock_guard<mutex> lock(global_cache_lock);
 	if (!global_metadata_cache) {
-		global_metadata_cache = make_uniq<AzureMetadataCache>(false, true);
+		global_metadata_cache = make_uniq<AzureMetadataCache>(false);
 	}
 	return global_metadata_cache.get();
 }
@@ -130,8 +130,7 @@ optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetMetadataCache(option
 		return GetGlobalMetadataCache();
 	}
 	if (client_context) {
-		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true, false)
-		    .get();
+		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true).get();
 	}
 	return nullptr;
 }

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -32,6 +32,22 @@ static string GetFileType(const Value &value) {
 	return type;
 }
 
+static string GetMetadataCacheAlias(const string &path) {
+	if (path.rfind("azure://", 0) == 0) {
+		return "az://" + path.substr(8);
+	}
+	if (path.rfind("az://", 0) == 0) {
+		return "azure://" + path.substr(5);
+	}
+	if (path.rfind("abfss://", 0) == 0) {
+		return "abfs://" + path.substr(8);
+	}
+	if (path.rfind("abfs://", 0) == 0) {
+		return "abfss://" + path.substr(7);
+	}
+	return string();
+}
+
 AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
                                  FileType file_type, const AzureOptions &options,
                                  optional_ptr<AzureMetadataCache> metadata_cache_p)
@@ -148,6 +164,12 @@ void AzureStorageFileSystem::InvalidateMetadata(optional_ptr<FileOpener> opener,
 	auto metadata_cache = GetMetadataCache(opener);
 	if (metadata_cache) {
 		metadata_cache->Erase(path);
+		// Scheme aliases can address the same remote object while retaining distinct secret scopes.
+		// Invalidate both spellings without merging their cache entries.
+		auto alias = GetMetadataCacheAlias(path);
+		if (!alias.empty()) {
+			metadata_cache->Erase(alias);
+		}
 	}
 }
 

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -125,7 +125,7 @@ bool AzureStorageFileSystem::ParseAzureMetadataCacheEnabled(optional_ptr<FileOpe
 optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetGlobalMetadataCache() {
 	lock_guard<mutex> lock(global_cache_lock);
 	if (!global_metadata_cache) {
-		global_metadata_cache = make_uniq<AzureMetadataCache>(false, true);
+		global_metadata_cache = make_uniq<AzureMetadataCache>(false);
 	}
 	return global_metadata_cache.get();
 }
@@ -140,8 +140,7 @@ optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetMetadataCache(option
 		return GetGlobalMetadataCache();
 	}
 	if (client_context) {
-		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true, false)
-		    .get();
+		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true).get();
 	}
 	return nullptr;
 }

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -79,8 +79,7 @@ AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo 
 		}
 	}
 	const bool has_complete_file_info = has_length && !etag.empty();
-	if (has_file_type && has_last_modified &&
-	    (file_type == FileType::FILE_TYPE_DIR || has_complete_file_info)) {
+	if (has_file_type && has_last_modified && (file_type == FileType::FILE_TYPE_DIR || has_complete_file_info)) {
 		SetFileInfo(file_type, length, last_modified, etag);
 	}
 }

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -24,53 +24,162 @@ void AzureContextState::QueryEnd() {
 	is_valid = false;
 }
 
+static string GetFileType(const Value &value) {
+	auto type = value.ToString();
+	if (!type.empty() && type.front() == '\'' && type.back() == '\'' && type.size() >= 2) {
+		type = type.substr(1, type.size() - 2);
+	}
+	return type;
+}
+
 AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-                                 FileType file_type, const AzureOptions &options)
+                                 FileType file_type, const AzureOptions &options,
+                                 optional_ptr<AzureMetadataCache> metadata_cache_p)
     : FileHandle(fs, info.path, flags), flags(flags),
       // File info
       is_remote_loaded(false), file_type(file_type), length(0), last_modified(0),
       // Read info
       buffer_available(0), buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0),
       // Options
-      options(options) {
+      options(options), metadata_cache(metadata_cache_p) {
 	if (!flags.RequireParallelAccess() && !flags.DirectIO()) {
 		read_buffer = duckdb::unique_ptr<data_t[]>(new data_t[options.read_buffer_size]);
 	}
 
 	// Set metadata of file when available, it avoids to invoke to the storage to get them.
+	bool has_file_type = file_type != FileType::FILE_TYPE_INVALID;
+	bool has_length = false;
+	bool has_last_modified = false;
 	if (info.extended_info) {
 		auto &opts = info.extended_info->options;
+		auto type_entry = opts.find("type");
+		if (type_entry != opts.end()) {
+			auto type = GetFileType(type_entry->second);
+			if (type == "directory") {
+				file_type = FileType::FILE_TYPE_DIR;
+				has_file_type = true;
+			} else if (type == "file") {
+				file_type = FileType::FILE_TYPE_REGULAR;
+				has_file_type = true;
+			}
+		}
 		auto entry1 = opts.find("file_size");
 		if (entry1 != opts.end()) {
 			length = entry1->second.GetValue<uint64_t>();
+			has_length = true;
 		}
 		auto entry2 = opts.find("last_modified");
 		if (entry2 != opts.end()) {
 			last_modified = entry2->second.GetValue<timestamp_t>();
+			has_last_modified = true;
 		}
 		auto entry3 = opts.find("etag");
 		if (entry3 != opts.end()) {
 			etag = StringValue::Get(entry3->second);
 		}
-		// When glob supplied the full metadata triplet for a read, skip the HEAD (GetProperties) on open.
-		// Exclude trailing-slash paths: those follow the S3/Azure "foo/" dir-marker convention and must
-		// still be resolved to FILE_TYPE_DIR by LoadRemoteFileInfo rather than pre-typed as a regular file.
-		const bool have_all = entry1 != opts.end() && entry2 != opts.end() && entry3 != opts.end();
-		const bool looks_like_dir = !info.path.empty() && info.path.back() == '/';
-		if (have_all && !looks_like_dir && flags.OpenForReading() && !flags.OpenForWriting()) {
-			file_type = FileType::FILE_TYPE_REGULAR;
-			is_remote_loaded = true;
-		}
 	}
+	const bool has_complete_file_info = has_length && !etag.empty();
+	if (has_file_type && has_last_modified &&
+	    (file_type == FileType::FILE_TYPE_DIR || has_complete_file_info)) {
+		SetFileInfo(file_type, length, last_modified, etag);
+	}
+}
+
+void AzureFileHandle::SetFileInfo(FileType file_type_p, idx_t length_p, timestamp_t last_modified_p,
+                                  const string &etag_p) {
+	is_remote_loaded = true;
+	file_type = file_type_p;
+	length = file_type_p == FileType::FILE_TYPE_DIR ? 0 : length_p;
+	last_modified = last_modified_p;
+	etag = etag_p;
+	file_offset = 0;
 }
 
 bool AzureFileHandle::PostConstruct() {
 	return static_cast<AzureStorageFileSystem &>(file_system).LoadFileInfo(*this);
 }
 
+static bool CanUseMetadataCache(const AzureFileHandle &handle) {
+	return handle.metadata_cache && !handle.flags.OpenForWriting() && !handle.flags.OpenForAppending() &&
+	       !handle.flags.ExclusiveCreate();
+}
+
+static AzureFileInfo GetCacheEntry(const AzureFileHandle &handle) {
+	AzureFileInfo info;
+	info.file_type = handle.file_type;
+	info.length = handle.length;
+	info.last_modified = handle.last_modified;
+	info.etag = handle.etag;
+	return info;
+}
+
+bool AzureStorageFileSystem::ParseAzureMetadataCacheEnabled(optional_ptr<FileOpener> opener) {
+	Value metadata_cache_val;
+	if (FileOpener::TryGetCurrentSetting(opener, "enable_http_metadata_cache", metadata_cache_val) &&
+	    !metadata_cache_val.IsNull()) {
+		return metadata_cache_val.GetValue<bool>();
+	}
+	return false;
+}
+
+optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetGlobalMetadataCache() {
+	lock_guard<mutex> lock(global_cache_lock);
+	if (!global_metadata_cache) {
+		global_metadata_cache = make_uniq<AzureMetadataCache>(false, true);
+	}
+	return global_metadata_cache.get();
+}
+
+optional_ptr<AzureMetadataCache> AzureStorageFileSystem::GetMetadataCache(optional_ptr<FileOpener> opener) {
+	auto db = FileOpener::TryGetDatabase(opener);
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (!db) {
+		return nullptr;
+	}
+	if (ParseAzureMetadataCacheEnabled(opener)) {
+		return GetGlobalMetadataCache();
+	}
+	if (client_context) {
+		return client_context->registered_state->GetOrCreate<AzureMetadataCache>("azure_metadata_cache", true, false)
+		    .get();
+	}
+	return nullptr;
+}
+
+void AzureStorageFileSystem::InvalidateMetadata(optional_ptr<FileOpener> opener, const string &path) {
+	auto metadata_cache = GetMetadataCache(opener);
+	if (metadata_cache) {
+		metadata_cache->Erase(path);
+	}
+}
+
 bool AzureStorageFileSystem::LoadFileInfo(AzureFileHandle &handle) {
 	try {
+		if (handle.IsRemoteLoaded()) {
+			if (CanUseMetadataCache(handle)) {
+				handle.metadata_cache->Insert(handle.path, GetCacheEntry(handle));
+			}
+			if (handle.flags.ReturnNullIfExists()) {
+				return false;
+			}
+			return true;
+		}
+		if (CanUseMetadataCache(handle)) {
+			AzureFileInfo cached_info;
+			if (handle.metadata_cache->Find(handle.path, cached_info)) {
+				handle.SetFileInfo(cached_info.file_type, cached_info.length, cached_info.last_modified,
+				                   cached_info.etag);
+				if (handle.flags.ReturnNullIfExists()) {
+					return false;
+				}
+				return true;
+			}
+		}
+
 		LoadRemoteFileInfo(handle);
+		if (CanUseMetadataCache(handle)) {
+			handle.metadata_cache->Insert(handle.path, GetCacheEntry(handle));
+		}
 		if (handle.flags.ReturnNullIfExists()) {
 			return false;
 		}

--- a/src/include/azure_blob_filesystem.hpp
+++ b/src/include/azure_blob_filesystem.hpp
@@ -28,7 +28,7 @@ class AzureBlobStorageFileSystem;
 class AzureBlobStorageFileHandle : public AzureFileHandle {
 public:
 	AzureBlobStorageFileHandle(AzureBlobStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-	                           const AzureReadOptions &read_options,
+	                           const AzureReadOptions &read_options, optional_ptr<AzureMetadataCache> metadata_cache,
 	                           Azure::Storage::Blobs::BlockBlobClient blob_client);
 	~AzureBlobStorageFileHandle() override = default;
 

--- a/src/include/azure_blob_filesystem.hpp
+++ b/src/include/azure_blob_filesystem.hpp
@@ -28,7 +28,8 @@ class AzureBlobStorageFileSystem;
 class AzureBlobStorageFileHandle : public AzureFileHandle {
 public:
 	AzureBlobStorageFileHandle(AzureBlobStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-	                           const AzureOptions &options, Azure::Storage::Blobs::BlockBlobClient blob_client);
+	                           const AzureOptions &options, optional_ptr<AzureMetadataCache> metadata_cache,
+	                           Azure::Storage::Blobs::BlockBlobClient blob_client);
 	~AzureBlobStorageFileHandle() override = default;
 
 	void StageWriteBuffer();

--- a/src/include/azure_dfs_filesystem.hpp
+++ b/src/include/azure_dfs_filesystem.hpp
@@ -29,7 +29,7 @@ class AzureDfsStorageFileSystem;
 class AzureDfsStorageFileHandle : public AzureFileHandle {
 public:
 	AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-	                          const AzureReadOptions &read_options,
+	                          const AzureReadOptions &read_options, optional_ptr<AzureMetadataCache> metadata_cache,
 	                          Azure::Storage::Files::DataLake::DataLakeFileClient client);
 	~AzureDfsStorageFileHandle() override = default;
 

--- a/src/include/azure_dfs_filesystem.hpp
+++ b/src/include/azure_dfs_filesystem.hpp
@@ -28,7 +28,8 @@ class AzureDfsStorageFileSystem;
 class AzureDfsStorageFileHandle : public AzureFileHandle {
 public:
 	AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags,
-	                          const AzureOptions &options, Azure::Storage::Files::DataLake::DataLakeFileClient client);
+	                          const AzureOptions &options, optional_ptr<AzureMetadataCache> metadata_cache,
+	                          Azure::Storage::Files::DataLake::DataLakeFileClient client);
 	~AzureDfsStorageFileHandle() override = default;
 
 	void StageWriteBuffer();

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -13,8 +13,6 @@
 #include <azure/core/datetime.hpp>
 #include <cstdint>
 #include <ctime>
-#include <shared_mutex>
-
 namespace duckdb {
 
 struct AzureReadOptions {
@@ -35,17 +33,17 @@ public:
 	}
 
 	void Insert(const string &path, const AzureFileInfo &val) {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map[path] = val;
 	}
 
 	void Erase(const string &path) {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map.erase(path);
 	}
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
-		std::shared_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		auto lookup = map.find(path);
 		if (lookup == map.end()) {
 			return false;
@@ -55,7 +53,7 @@ public:
 	}
 
 	void Clear() {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map.clear();
 	}
 
@@ -67,7 +65,7 @@ public:
 
 private:
 	// Query-local caches are still shared across parallel tasks within a query.
-	std::shared_mutex lock;
+	mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
 };

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -31,38 +31,21 @@ struct AzureFileInfo {
 
 class AzureMetadataCache : public ClientContextState {
 public:
-	explicit AzureMetadataCache(bool flush_on_query_end_p, bool shared_p)
-	    : flush_on_query_end(flush_on_query_end_p), shared(shared_p) {
+	explicit AzureMetadataCache(bool flush_on_query_end_p) : flush_on_query_end(flush_on_query_end_p) {
 	}
 
 	void Insert(const string &path, const AzureFileInfo &val) {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map[path] = val;
-		} else {
-			map[path] = val;
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map[path] = val;
 	}
 
 	void Erase(const string &path) {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map.erase(path);
-		} else {
-			map.erase(path);
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map.erase(path);
 	}
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
-		if (shared) {
-			std::shared_lock<std::shared_mutex> parallel_lock(lock);
-			auto lookup = map.find(path);
-			if (lookup == map.end()) {
-				return false;
-			}
-			ret_val = lookup->second;
-			return true;
-		}
+		std::shared_lock<std::shared_mutex> parallel_lock(lock);
 		auto lookup = map.find(path);
 		if (lookup == map.end()) {
 			return false;
@@ -72,12 +55,8 @@ public:
 	}
 
 	void Clear() {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map.clear();
-		} else {
-			map.clear();
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map.clear();
 	}
 
 	void QueryEnd(ClientContext &context) override {
@@ -87,10 +66,10 @@ public:
 	}
 
 private:
+	// Query-local caches are still shared across parallel tasks within a query.
 	std::shared_mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
-	bool shared;
 };
 
 class AzureContextState : public ClientContextState {

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -4,7 +4,9 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/logging/file_system_logger.hpp"
 #include "duckdb/main/client_context_state.hpp"
 
@@ -18,6 +20,76 @@ struct AzureReadOptions {
 	int32_t transfer_concurrency = 5;
 	int64_t transfer_chunk_size = 1 * 1024 * 1024;
 	idx_t buffer_size = 1 * 1024 * 1024;
+};
+
+struct AzureFileInfo {
+	FileType file_type = FileType::FILE_TYPE_INVALID;
+	idx_t length = 0;
+	timestamp_t last_modified;
+};
+
+class AzureMetadataCache : public ClientContextState {
+public:
+	explicit AzureMetadataCache(bool flush_on_query_end_p, bool shared_p)
+	    : flush_on_query_end(flush_on_query_end_p), shared(shared_p) {
+	}
+
+	void Insert(const string &path, const AzureFileInfo &val) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map[path] = val;
+		} else {
+			map[path] = val;
+		}
+	}
+
+	void Erase(const string &path) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map.erase(path);
+		} else {
+			map.erase(path);
+		}
+	}
+
+	bool Find(const string &path, AzureFileInfo &ret_val) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			auto lookup = map.find(path);
+			if (lookup == map.end()) {
+				return false;
+			}
+			ret_val = lookup->second;
+			return true;
+		}
+		auto lookup = map.find(path);
+		if (lookup == map.end()) {
+			return false;
+		}
+		ret_val = lookup->second;
+		return true;
+	}
+
+	void Clear() {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map.clear();
+		} else {
+			map.clear();
+		}
+	}
+
+	void QueryEnd(ClientContext &context) override {
+		if (flush_on_query_end) {
+			Clear();
+		}
+	}
+
+private:
+	mutex lock;
+	unordered_map<string, AzureFileInfo> map;
+	bool flush_on_query_end;
+	bool shared;
 };
 
 class AzureContextState : public ClientContextState {
@@ -51,6 +123,7 @@ class AzureStorageFileSystem;
 class AzureFileHandle : public FileHandle {
 public:
 	virtual bool PostConstruct();
+	void SetFileInfo(FileType file_type_p, idx_t length_p, timestamp_t last_modified_p);
 
 	bool IsRemoteLoaded() {
 		return is_remote_loaded;
@@ -62,7 +135,7 @@ public:
 
 protected:
 	AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags, FileType file_type,
-	                const AzureReadOptions &read_options);
+	                const AzureReadOptions &read_options, optional_ptr<AzureMetadataCache> metadata_cache);
 
 public:
 	FileOpenFlags flags;
@@ -83,6 +156,7 @@ public:
 	idx_t buffer_end;
 
 	const AzureReadOptions read_options;
+	optional_ptr<AzureMetadataCache> metadata_cache;
 };
 
 class AzureStorageFileSystem : public FileSystem {
@@ -133,9 +207,17 @@ protected:
 
 	virtual void LoadRemoteFileInfo(AzureFileHandle &handle) = 0;
 	static AzureReadOptions ParseAzureReadOptions(optional_ptr<FileOpener> opener);
+	static bool ParseAzureMetadataCacheEnabled(optional_ptr<FileOpener> opener);
+	optional_ptr<AzureMetadataCache> GetMetadataCache(optional_ptr<FileOpener> opener);
+	void InvalidateMetadata(optional_ptr<FileOpener> opener, const string &path);
 
 public:
 	static timestamp_t ToTimestamp(const Azure::DateTime &dt);
+
+private:
+	optional_ptr<AzureMetadataCache> GetGlobalMetadataCache();
+	mutex global_cache_lock;
+	duckdb::unique_ptr<AzureMetadataCache> global_metadata_cache;
 };
 
 } // namespace duckdb

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -13,6 +13,7 @@
 #include <azure/core/datetime.hpp>
 #include <cstdint>
 #include <ctime>
+#include <shared_mutex>
 
 namespace duckdb {
 
@@ -36,7 +37,7 @@ public:
 
 	void Insert(const string &path, const AzureFileInfo &val) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map[path] = val;
 		} else {
 			map[path] = val;
@@ -45,7 +46,7 @@ public:
 
 	void Erase(const string &path) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map.erase(path);
 		} else {
 			map.erase(path);
@@ -54,7 +55,7 @@ public:
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			std::shared_lock<std::shared_mutex> parallel_lock(lock);
 			auto lookup = map.find(path);
 			if (lookup == map.end()) {
 				return false;
@@ -72,7 +73,7 @@ public:
 
 	void Clear() {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map.clear();
 		} else {
 			map.clear();
@@ -86,7 +87,7 @@ public:
 	}
 
 private:
-	mutex lock;
+	std::shared_mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
 	bool shared;

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -39,38 +39,21 @@ struct AzureFileInfo {
 
 class AzureMetadataCache : public ClientContextState {
 public:
-	explicit AzureMetadataCache(bool flush_on_query_end_p, bool shared_p)
-	    : flush_on_query_end(flush_on_query_end_p), shared(shared_p) {
+	explicit AzureMetadataCache(bool flush_on_query_end_p) : flush_on_query_end(flush_on_query_end_p) {
 	}
 
 	void Insert(const string &path, const AzureFileInfo &val) {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map[path] = val;
-		} else {
-			map[path] = val;
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map[path] = val;
 	}
 
 	void Erase(const string &path) {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map.erase(path);
-		} else {
-			map.erase(path);
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map.erase(path);
 	}
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
-		if (shared) {
-			std::shared_lock<std::shared_mutex> parallel_lock(lock);
-			auto lookup = map.find(path);
-			if (lookup == map.end()) {
-				return false;
-			}
-			ret_val = lookup->second;
-			return true;
-		}
+		std::shared_lock<std::shared_mutex> parallel_lock(lock);
 		auto lookup = map.find(path);
 		if (lookup == map.end()) {
 			return false;
@@ -80,12 +63,8 @@ public:
 	}
 
 	void Clear() {
-		if (shared) {
-			unique_lock<std::shared_mutex> parallel_lock(lock);
-			map.clear();
-		} else {
-			map.clear();
-		}
+		unique_lock<std::shared_mutex> parallel_lock(lock);
+		map.clear();
 	}
 
 	void QueryEnd(ClientContext &context) override {
@@ -95,10 +74,10 @@ public:
 	}
 
 private:
+	// Query-local caches are still shared across parallel tasks within a query.
 	std::shared_mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
-	bool shared;
 };
 
 class AzureContextState : public ClientContextState {

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -4,7 +4,9 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/logging/file_system_logger.hpp"
 #include "duckdb/main/client_context_state.hpp"
 
@@ -25,6 +27,77 @@ struct AzureOptions {
 	idx_t read_buffer_size = (idx_t)8 * 1024 * 1024;
 	idx_t write_block_size = WRITE_BLOCK_SIZE_DEFAULT;
 	idx_t write_staged_blocks_per_commit = 0;
+};
+
+struct AzureFileInfo {
+	FileType file_type = FileType::FILE_TYPE_INVALID;
+	idx_t length = 0;
+	timestamp_t last_modified;
+	string etag;
+};
+
+class AzureMetadataCache : public ClientContextState {
+public:
+	explicit AzureMetadataCache(bool flush_on_query_end_p, bool shared_p)
+	    : flush_on_query_end(flush_on_query_end_p), shared(shared_p) {
+	}
+
+	void Insert(const string &path, const AzureFileInfo &val) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map[path] = val;
+		} else {
+			map[path] = val;
+		}
+	}
+
+	void Erase(const string &path) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map.erase(path);
+		} else {
+			map.erase(path);
+		}
+	}
+
+	bool Find(const string &path, AzureFileInfo &ret_val) {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			auto lookup = map.find(path);
+			if (lookup == map.end()) {
+				return false;
+			}
+			ret_val = lookup->second;
+			return true;
+		}
+		auto lookup = map.find(path);
+		if (lookup == map.end()) {
+			return false;
+		}
+		ret_val = lookup->second;
+		return true;
+	}
+
+	void Clear() {
+		if (shared) {
+			lock_guard<mutex> parallel_lock(lock);
+			map.clear();
+		} else {
+			map.clear();
+		}
+	}
+
+	void QueryEnd(ClientContext &context) override {
+		if (flush_on_query_end) {
+			Clear();
+		}
+	}
+
+private:
+	mutex lock;
+	unordered_map<string, AzureFileInfo> map;
+	bool flush_on_query_end;
+	bool shared;
 };
 
 class AzureContextState : public ClientContextState {
@@ -58,6 +131,7 @@ class AzureStorageFileSystem;
 class AzureFileHandle : public FileHandle {
 public:
 	virtual bool PostConstruct();
+	void SetFileInfo(FileType file_type_p, idx_t length_p, timestamp_t last_modified_p, const string &etag_p);
 
 	bool IsRemoteLoaded() {
 		return is_remote_loaded;
@@ -69,7 +143,7 @@ public:
 
 protected:
 	AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo &info, FileOpenFlags flags, FileType file_type,
-	                const AzureOptions &options);
+	                const AzureOptions &options, optional_ptr<AzureMetadataCache> metadata_cache);
 
 public:
 	FileOpenFlags flags;
@@ -89,8 +163,8 @@ public:
 	idx_t file_offset;
 	idx_t buffer_start;
 	idx_t buffer_end;
-
 	const AzureOptions options;
+	optional_ptr<AzureMetadataCache> metadata_cache;
 };
 
 class AzureStorageFileSystem : public FileSystem {
@@ -142,10 +216,18 @@ protected:
 
 	virtual void LoadRemoteFileInfo(AzureFileHandle &handle) = 0;
 	static AzureOptions ParseAzureOptions(optional_ptr<FileOpener> opener);
+	static bool ParseAzureMetadataCacheEnabled(optional_ptr<FileOpener> opener);
+	optional_ptr<AzureMetadataCache> GetMetadataCache(optional_ptr<FileOpener> opener);
+	void InvalidateMetadata(optional_ptr<FileOpener> opener, const string &path);
 
 public:
 	static timestamp_t ToTimestamp(const Azure::DateTime &dt);
 	static string StripETagQuotes(string etag);
+
+private:
+	optional_ptr<AzureMetadataCache> GetGlobalMetadataCache();
+	mutex global_cache_lock;
+	duckdb::unique_ptr<AzureMetadataCache> global_metadata_cache;
 };
 
 } // namespace duckdb

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -13,6 +13,7 @@
 #include <azure/core/datetime.hpp>
 #include <cstdint>
 #include <ctime>
+#include <shared_mutex>
 
 namespace duckdb {
 
@@ -44,7 +45,7 @@ public:
 
 	void Insert(const string &path, const AzureFileInfo &val) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map[path] = val;
 		} else {
 			map[path] = val;
@@ -53,7 +54,7 @@ public:
 
 	void Erase(const string &path) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map.erase(path);
 		} else {
 			map.erase(path);
@@ -62,7 +63,7 @@ public:
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			std::shared_lock<std::shared_mutex> parallel_lock(lock);
 			auto lookup = map.find(path);
 			if (lookup == map.end()) {
 				return false;
@@ -80,7 +81,7 @@ public:
 
 	void Clear() {
 		if (shared) {
-			lock_guard<mutex> parallel_lock(lock);
+			unique_lock<std::shared_mutex> parallel_lock(lock);
 			map.clear();
 		} else {
 			map.clear();
@@ -94,7 +95,7 @@ public:
 	}
 
 private:
-	mutex lock;
+	std::shared_mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
 	bool shared;

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -13,8 +13,6 @@
 #include <azure/core/datetime.hpp>
 #include <cstdint>
 #include <ctime>
-#include <shared_mutex>
-
 namespace duckdb {
 
 struct AzureOptions {
@@ -43,17 +41,17 @@ public:
 	}
 
 	void Insert(const string &path, const AzureFileInfo &val) {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map[path] = val;
 	}
 
 	void Erase(const string &path) {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map.erase(path);
 	}
 
 	bool Find(const string &path, AzureFileInfo &ret_val) {
-		std::shared_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		auto lookup = map.find(path);
 		if (lookup == map.end()) {
 			return false;
@@ -63,7 +61,7 @@ public:
 	}
 
 	void Clear() {
-		unique_lock<std::shared_mutex> parallel_lock(lock);
+		lock_guard<mutex> parallel_lock(lock);
 		map.clear();
 	}
 
@@ -75,7 +73,7 @@ public:
 
 private:
 	// Query-local caches are still shared across parallel tasks within a query.
-	std::shared_mutex lock;
+	mutex lock;
 	unordered_map<string, AzureFileInfo> map;
 	bool flush_on_query_end;
 };

--- a/test/sql/azure.test
+++ b/test/sql/azure.test
@@ -51,17 +51,17 @@ SET azure_http_stats = true;
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 2\.4 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Redoing query should still result in same request count
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 2\.4 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Testing public blobs
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM "azure://testing-public/l.parquet";
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 4\.8 MiB.*\#HEAD\: 1.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 2\.4 MiB.*\#HEAD\: 1.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
 

--- a/test/sql/azure.test
+++ b/test/sql/azure.test
@@ -51,17 +51,17 @@ SET azure_http_stats = true;
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 3.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Redoing query should still result in same request count
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 3.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 7\.2 MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Testing public blobs
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM "azure://testing-public/l.parquet";
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 4\.8 MiB.*\#HEAD\: 2.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: 4\.8 MiB.*\#HEAD\: 1.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
 

--- a/test/sql/azure.test
+++ b/test/sql/azure.test
@@ -51,17 +51,17 @@ SET azure_http_stats = true;
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 3.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Redoing query should still result in same request count
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 3.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
 
 # Testing public blobs
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM "azure://testing-public/l.parquet";
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 2.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: 1.*PUT\: 0.*\#POST\: 0.*
 

--- a/test/sql/azure.test
+++ b/test/sql/azure.test
@@ -51,13 +51,13 @@ SET azure_http_stats = true;
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: (0|2).*PUT\: 0.*\#POST\: 0.*
 
 # Redoing query should still result in same request count
 query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
 ----
-analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: 0.*PUT\: 0.*\#POST\: 0.*
+analyzed_plan	<REGEX>:.*HTTP Stats.*in\: \d[.]\d MiB.*\#HEAD\: 1.*GET\: (0|2).*PUT\: 0.*\#POST\: 0.*
 
 # Testing public blobs
 query II

--- a/test/sql/azure_etag.test
+++ b/test/sql/azure_etag.test
@@ -8,6 +8,8 @@ require parquet
 
 require-env AZURE_STORAGE_CONNECTION_STRING
 
+require-env AZ_TEMP_DIR
+
 statement ok
 SET azure_storage_connection_string = '{AZURE_STORAGE_CONNECTION_STRING}';
 
@@ -38,3 +40,35 @@ query II
 EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l*.parquet';
 ----
 analyzed_plan	<REGEX>:.*Azure HTTP Stats.*\#HEAD\: 0.*GET.*
+
+# -----------------------------------------------------------------------------
+# Global metadata cache: URI aliases for the same Blob invalidate each other
+
+statement ok
+SET enable_http_metadata_cache = true;
+
+statement ok
+COPY (SELECT i FROM range(10) t(i))
+TO 'az://{AZ_TEMP_DIR}/metadata-cache-alias.csv' (HEADER false);
+
+# Populate the global metadata cache through the short URI alias.
+query I
+SELECT count(*)
+FROM read_csv('az://{AZ_TEMP_DIR}/metadata-cache-alias.csv', header = false, columns = {'i': 'BIGINT'});
+----
+10
+
+# Overwrite the same Blob through the long URI alias. This must invalidate the
+# metadata inserted through az:// rather than leaving the old file length cached.
+statement ok
+COPY (SELECT i FROM range(1000) t(i))
+TO 'azure://{AZ_TEMP_DIR}/metadata-cache-alias.csv' (HEADER false);
+
+query I
+SELECT count(*)
+FROM read_csv('az://{AZ_TEMP_DIR}/metadata-cache-alias.csv', header = false, columns = {'i': 'BIGINT'});
+----
+1000
+
+statement ok
+RESET enable_http_metadata_cache;

--- a/test/sql/azure_glob.test
+++ b/test/sql/azure_glob.test
@@ -80,9 +80,9 @@ az://testing-public/l.csv
 az://testing-public/l.parquet
 az://testing-public/lineitem.csv
 
-# Recursive glob into the nested partitioned CSVs
+# Auto glob: ".../partitioned" -> ".../partitioned/*" via read_csv (and other multi file readers)
 query II
-SELECT l_shipmode, COUNT(*) FROM read_csv('az://testing-public/partitioned/**/*.csv') GROUP BY l_shipmode ORDER BY l_shipmode;
+SELECT l_shipmode, COUNT(*) FROM read_csv('az://testing-public/partitioned') GROUP BY l_shipmode ORDER BY l_shipmode;
 ----
 AIR	2318
 SHIP	2301

--- a/test/sql/azure_glob.test
+++ b/test/sql/azure_glob.test
@@ -80,9 +80,9 @@ az://testing-public/l.csv
 az://testing-public/l.parquet
 az://testing-public/lineitem.csv
 
-# Auto glob: ".../partitioned" -> ".../partitioned/*" via read_csv (and other multi file readers)
+# Recursive glob into the nested partitioned CSVs
 query II
-SELECT l_shipmode, COUNT(*) FROM read_csv('az://testing-public/partitioned') GROUP BY l_shipmode ORDER BY l_shipmode;
+SELECT l_shipmode, COUNT(*) FROM read_csv('az://testing-public/partitioned/**/*.csv') GROUP BY l_shipmode ORDER BY l_shipmode;
 ----
 AIR	2318
 SHIP	2301


### PR DESCRIPTION
# Azure metadata cache hookup and Azure integration test updates

## Summary

This PR wires `duckdb-azure` into DuckDB HTTPFS-style metadata caching and restores Azure multi-file auto-glob behavior for bare Blob directory paths on HNS-backed accounts.

### What changed

- Hook Azure file metadata loading (`GetProperties()` / file info lookup) into HTTPFS-aligned metadata cache behavior.
  - `enable_http_metadata_cache = false` now uses a **query-local** cache.
  - `enable_http_metadata_cache = true` now uses a **shared/global** cache.
- Seed file metadata from Azure blob/DFS listings so file size and last-modified can be reused without an extra metadata round trip.
- Invalidate Azure metadata cache entries on mutating operations:
  - write/append opens
  - delete/remove
  - create directory
- Use `shared_mutex` for the shared/global `AzureMetadataCache` to allow concurrent readers with exclusive writes.
- Make the Blob no-wildcard `Glob` path return only regular files so HNS directories do not suppress DuckDB's fallback auto-glob for multi-file readers.
- In Blob glob results, only stamp `type=file` for non-empty items before seeding metadata, so flat HNS Blob listings do not misclassify directory entries as files.
- Update Azure SQLLogicTests:
  - adjust stale HTTP-stats byte expectations in `test/sql/azure.test`
  - restore `test/sql/azure_glob.test` to the original auto-glob form (`read_csv('az://.../partitioned')`)

## Why

Before this change, repeated Azure file opens inside a single query were still issuing repeated metadata lookups. On the benchmark parquet workload, that kept Azure `HEAD` traffic high and wall time far above direct download speed.

The metadata-cache hookup removes those repeated metadata calls while preserving HTTPFS-style semantics:

- query-local reuse by default
- shared/global reuse when explicitly enabled

## Benchmark results

Benchmark workload:

- `76.3 MiB` uncompressed parquet
- `20` row groups

Primary before/after comparison (same `curl` + object-cache-on + `4 MB / 4 MB` setup):

| Metric | Before metadata-cache hook | After metadata-cache hook |
| --- | ---: | ---: |
| real median | `47.257 s` | `14.443 s` |
| throughput | `1.61 MiB/s` | `5.28 MiB/s` |
| `#HEAD` | `22` | `1` |
| `#GET` | `21` | `21` |

Net result:

- about **3.27x faster** wall time on this workload
- Azure metadata requests collapsed from **22 HEADs to 1**
- These measurements were collected on a dev box and may reflect higher network latency than a storage-adjacent environment; that extra latency can amplify the cost of repeated metadata requests, so the measured speedup may be skewed upward relative to a lower-latency setup.

Post-fix comparison for the two configurations we want to highlight:

| Configuration | real (s) | Throughput (MiB/s) | `#HEAD` | `#GET` |
| --- | ---: | ---: | ---: | ---: |
| `chunk = 4 MiB`, `buffer = 4 MiB` | `14.443` | `5.28` | `1` | `21` |
| `chunk = 1 MiB`, `buffer = 1 MiB` | `14.194` | `5.38` | `1` | `81` |

## Validation

- Rebuilt locally with MSVC/CMake.
- Final result: **9 test cases, 141 assertions, all passed** for the targeted Azure integration subset.

