### PR TITLE
Fix Windows Azurite build caching

### DIFF
--- a/.github/workflows/LocalTesting.yml
+++ b/.github/workflows/LocalTesting.yml
@@ -165,6 +165,7 @@ jobs:
       VCPKG_TARGET_TRIPLET: 'x64-windows'
       VCPKG_ROOT: ${{ github.workspace }}\vcpkg
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake
+      GEN: ninja
       AZURE_STORAGE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;'
       # AZ protocol vars
       AZ_STORAGE_ACCOUNT: devstoreaccount1
@@ -178,6 +179,9 @@ jobs:
           submodules: 'true'
 
       - uses: actions/setup-node@v4
+
+      - name: Install Ninja
+        run: choco install ninja -y --no-progress
 
       - name: Launch & populate Azure test service
         run: |
@@ -195,30 +199,28 @@ jobs:
         with:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
 
-      - &sccache
-        name: Add sccache
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          variant: sccache
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
-          restore-keys: ${{ github.job }}-${{ matrix.duckdb_arch }}
-          verbose: 1
+      - *ccache
 
       - name: Build extension
+        shell: cmd
+        env:
+          EXT_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           make release
 
       - name: Test Extension
         shell: bash
         run: |
-          scripts/env_azurite build/release/test/Release/unittest.exe --test-dir . "[sql]"
+          scripts/env_azurite build/release/test/unittest.exe --test-dir . "[sql]"
 
       - name: Run test data integrity check
+        shell: bash
         run: |
           ls build
           ls build/release
-          ./build/release/Release/duckdb.exe -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, CONNECTION_STRING '$AZURE_STORAGE_CONNECTION_STRING')"
-          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 scripts/env_azurite build/release/test/Release/unittest.exe "*test/sql/test_data_integrity.test"
+          ./build/release/duckdb.exe -c "CREATE PERSISTENT SECRET s1 (TYPE AZURE, CONNECTION_STRING '$AZURE_STORAGE_CONNECTION_STRING')"
+          DUCKDB_AZURE_PERSISTENT_SECRET_AVAILABLE=1 scripts/env_azurite build/release/test/unittest.exe "*test/sql/test_data_integrity.test"
 
       - name: Azure test server log
         if: always()


### PR DESCRIPTION
# Fix Windows Azurite build caching

 ## Summary

 This PR fixes the Windows job in the `Azurite (local) functional tests` workflow so compiler caching is actually
used.

 Previously the Windows job configured `sccache`, but the build itself used DuckDB/CMake auto-detection and selected
 `C:/Strawberry/c/bin/ccache.exe` while building through the Visual Studio/MSBuild generator. As a result, `sccache`
 saw zero compiler requests and failed to save a cache.

 ## What changed

 - Switch the Windows Azurite job to the Ninja generator with `GEN: ninja`.
 - Install Ninja in the Windows job.
 - Reuse the same `ccache` action path as Linux/macOS instead of configuring `sccache`.
 - Force CMake to use `ccache` with:
   - `-DCMAKE_C_COMPILER_LAUNCHER=ccache`
   - `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache`
 - Initialize the MSVC environment explicitly via `vcvars64.bat`.
 - Update Windows test paths for Ninja’s single-config output layout:
   - `build/release/test/unittest.exe`
   - `build/release/duckdb.exe`

 ## Validation

 Verified on fork workflow runs for branch `buildcache`.

 First patched run, cold cache: `25012290773` https://github.com/zsy056/duckdb-azure/actions/runs/25012290773/job/73250903438

 | Metric | Result |
 | --- | ---: |
 | Workflow conclusion | success |
 | Windows build step | `1407s` |
 | Cacheable compiler calls | `441 / 445` |
 | Cache hits | `36 / 441` |
 | Cache misses | `405 / 441` |
 | Cache saved | `93.5 MB` ccache archive |

 Second patched run, warm cache: `25016632847`  https://github.com/zsy056/duckdb-azure/actions/runs/25016632847/job/73266043040

 | Metric | Result |
 | --- | ---: |
 | Workflow conclusion | success |
 | Windows job total time | `11.6 min` |
 | Windows build step | `324s` |
 | Cacheable compiler calls | `441 / 445` |
 | Cache hits | `438 / 441` (`99.32%`) |
 | Cache misses | `3 / 441` (`0.68%`) |

 This confirms the Windows Azurite job now restores and uses compiler cache entries effectively.
