### PR TITLE
Update buffer/stage/commit strategy during writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,4 +150,4 @@ cd duckdb_azure
 GEN=ninja VCPKG_TOOLCHAIN_PATH=$PWD/../vcpkg/scripts/buildsystems/vcpkg.cmake make
 ```
 
-Please also refer to our [Build Guide](https://duckdb.org/dev/building) and [Contribution Guide](<[CONTRIBUTING.md](https://github.com/duckdb/duckdb/blob/main/CONTRIBUTING.md)>).
+Please also refer to our [Build Guide](https://duckdb.org/dev/building) and [Contribution Guide](https://github.com/duckdb/duckdb/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -99,6 +99,34 @@ IDs may be specified.
 
 See also [Azure Identity Managed Identity Support](https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/identity/azure-identity#managed-identity-support)
 
+## Writing
+
+Writing to Azure Storage stages blocks during upload; staged blocks are not
+visible until committed which occurs during a sync or close call. Thus large
+uploads may not be visible to standard Azure tooling until whole file has been
+written.
+
+### File size limit
+
+Azure [hard-limits a blob to **50,000
+blocks**](https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets).
+With the default block size of 8 MiB this caps blob size at roughly **390
+GiB**. To write larger files, increase the block size:
+
+```sql
+SET azure_write_block_size = '128MiB';  -- raises the cap to ~6.1 TiB
+SET azure_write_block_size = '4000MiB'; -- maximum block size, cap ~190 TiB
+```
+
+The block size can be any positive value up to 4,000 MiB (Azure's per-request limit). Set to `0` to restore the default (8 MiB).
+
+### Write settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `azure_write_block_size` | `8MiB` | Size of each block for Blob/DFS writes. `0` restores the default. Max 4,000 MiB. Increase to raise the file size ceiling. |
+| `azure_write_staged_blocks_per_commit` | `0` | Blocks staged before an intermediate commit. `0` disables intermediate commits; partial writes are not visible until the file is closed. |
+
 ## Supported architectures
 
 The extension is tested & distributed for Linux (x64, arm64), MacOS (x64, arm64) and Windows (x64)
@@ -122,4 +150,4 @@ cd duckdb_azure
 GEN=ninja VCPKG_TOOLCHAIN_PATH=$PWD/../vcpkg/scripts/buildsystems/vcpkg.cmake make
 ```
 
-Please also refer to our [Build Guide](https://duckdb.org/dev/building) and [Contribution Guide]([CONTRIBUTING.md](https://github.com/duckdb/duckdb/blob/main/CONTRIBUTING.md)).
+Please also refer to our [Build Guide](https://duckdb.org/dev/building) and [Contribution Guide](<[CONTRIBUTING.md](https://github.com/duckdb/duckdb/blob/main/CONTRIBUTING.md)>).

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -78,11 +78,23 @@ AzureBlobStorageFileHandle::AzureBlobStorageFileHandle(AzureBlobStorageFileSyste
     : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, opts), blob_client(std::move(blob_client)) {
 }
 
+void AzureBlobStorageFileHandle::StageWriteBuffer() {
+	if (write_buffer_offset == 0) {
+		return;
+	}
+	auto block_id = MakeBlockId(static_cast<uint32_t>(committed_block_count) + staged_block_count);
+	auto body_stream = Azure::Core::IO::MemoryBodyStream(write_buffer.get(), write_buffer_offset);
+	blob_client.StageBlock(block_id, body_stream); // throws on error
+	staged_block_count++;
+	write_buffer_offset = 0;
+}
+
 void AzureBlobStorageFileHandle::Sync() {
 	if (!(flags.OpenForWriting() || flags.OpenForAppending())) {
 		return;
 	}
 	try {
+		StageWriteBuffer();
 		if (staged_block_count == 0) {
 			return;
 		}
@@ -420,6 +432,8 @@ int64_t AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int6
 	return nr_bytes;
 }
 
+// Write pipeline: data accumulates in write_buffer; full blocks are StageBlock'd to Azure;
+// on Sync/Close, all staged blocks are committed via CommitBlockList.
 void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	D_ASSERT(nr_bytes >= 0);
 	auto &afh = handle.Cast<AzureBlobStorageFileHandle>();
@@ -430,12 +444,28 @@ void AzureBlobStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t
 
 	D_ASSERT(location == afh.file_offset);
 
-	auto block_id = MakeBlockId(static_cast<uint32_t>(afh.committed_block_count) + afh.staged_block_count);
-	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
-	afh.blob_client.StageBlock(block_id, body_stream); // throws on error
-	afh.staged_block_count++;
-	if (afh.staged_block_count >= afh.options.write_staged_blocks_max) {
-		afh.Sync();
+	const idx_t block_size = afh.options.write_block_size;
+	auto *src = static_cast<const uint8_t *>(buffer);
+	idx_t remaining = static_cast<idx_t>(nr_bytes);
+
+	while (remaining > 0) {
+		if (!afh.write_buffer) {
+			afh.write_buffer = duckdb::unique_ptr<data_t[]>(new data_t[block_size]);
+		}
+		idx_t space = block_size - afh.write_buffer_offset;
+		idx_t to_copy = MinValue<idx_t>(space, remaining);
+		memcpy(afh.write_buffer.get() + afh.write_buffer_offset, src, to_copy);
+		afh.write_buffer_offset += to_copy;
+		src += to_copy;
+		remaining -= to_copy;
+
+		if (afh.write_buffer_offset == block_size) {
+			afh.StageWriteBuffer();
+			if (afh.options.write_staged_blocks_per_commit > 0 &&
+			    afh.staged_block_count >= afh.options.write_staged_blocks_per_commit) {
+				afh.Sync();
+			}
+		}
 	}
 
 	afh.file_offset += nr_bytes;

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -128,7 +128,7 @@ void AzureDfsStorageFileHandle::Sync(bool close) {
 		}
 		Azure::Storage::Files::DataLake::FlushFileOptions flush_opts;
 		flush_opts.Close = close;
-		file_client.Flush(file_offset, flush_opts);
+		file_client.Flush(staged_offset, flush_opts);
 		committed_block_count += staged_block_count;
 		staged_block_count = 0;
 	} catch (const Azure::Storage::StorageException &e) {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -106,11 +106,34 @@ AzureDfsStorageFileHandle::AzureDfsStorageFileHandle(AzureDfsStorageFileSystem &
     : AzureFileHandle(fs, info, flags, FileType::FILE_TYPE_INVALID, options), file_client(std::move(client)) {
 }
 
+void AzureDfsStorageFileHandle::StageWriteBuffer() {
+	if (write_buffer_offset == 0) {
+		return;
+	}
+	auto body_stream = Azure::Core::IO::MemoryBodyStream(write_buffer.get(), write_buffer_offset);
+	file_client.Append(body_stream, staged_offset);
+	staged_offset += write_buffer_offset;
+	staged_block_count++;
+	write_buffer_offset = 0;
+}
+
 void AzureDfsStorageFileHandle::Sync(bool close) {
-	if (flags.OpenForWriting() || flags.OpenForAppending()) {
+	if (!(flags.OpenForWriting() || flags.OpenForAppending())) {
+		return;
+	}
+	try {
+		StageWriteBuffer();
+		if (staged_block_count == 0 && !close) {
+			return;
+		}
 		Azure::Storage::Files::DataLake::FlushFileOptions flush_opts;
 		flush_opts.Close = close;
 		file_client.Flush(file_offset, flush_opts);
+		committed_block_count += staged_block_count;
+		staged_block_count = 0;
+	} catch (const Azure::Storage::StorageException &e) {
+		throw IOException("AzureDfsStorageFileSystem FileSync of '%s' failed with %s Reason Phrase: %s", GetPath(),
+		                  e.ErrorCode, e.ReasonPhrase);
 	}
 }
 
@@ -360,6 +383,8 @@ int64_t AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64
 	return nr_bytes;
 }
 
+// Write pipeline: data accumulates in write_buffer; full blocks are Append'd to Azure (staged, not yet visible);
+// on Sync/Close, staged blocks are committed via Flush.
 void AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	D_ASSERT(nr_bytes >= 0);
 	auto &afh = handle.Cast<AzureDfsStorageFileHandle>();
@@ -373,10 +398,30 @@ void AzureDfsStorageFileSystem::Write(FileHandle &handle, void *buffer, int64_t 
 		throw InternalException("Write supported only sequentially or at location=0");
 	}
 
-	auto body_stream = Azure::Core::IO::MemoryBodyStream(static_cast<uint8_t *>(buffer), nr_bytes);
-	auto append_res = afh.file_client.Append(body_stream, afh.file_offset);
-	// NOTE: cannot get TS when using paired append + flush
-	// afh.last_modified = ToTimestamp(append_res.Value.LastModified);
+	const idx_t block_sz = afh.options.write_block_size;
+	auto *src = static_cast<const uint8_t *>(buffer);
+	idx_t remaining = static_cast<idx_t>(nr_bytes);
+
+	while (remaining > 0) {
+		if (!afh.write_buffer) {
+			afh.write_buffer = duckdb::unique_ptr<data_t[]>(new data_t[block_sz]);
+		}
+		idx_t space = block_sz - afh.write_buffer_offset;
+		idx_t to_copy = MinValue<idx_t>(space, remaining);
+		memcpy(afh.write_buffer.get() + afh.write_buffer_offset, src, to_copy);
+		afh.write_buffer_offset += to_copy;
+		src += to_copy;
+		remaining -= to_copy;
+
+		if (afh.write_buffer_offset == block_sz) {
+			afh.StageWriteBuffer();
+			if (afh.options.write_staged_blocks_per_commit > 0 &&
+			    afh.staged_block_count >= afh.options.write_staged_blocks_per_commit) {
+				afh.Sync();
+			}
+		}
+	}
+
 	afh.file_offset += nr_bytes;
 	afh.length += nr_bytes;
 	DUCKDB_LOG_FILE_SYSTEM_WRITE(handle, nr_bytes, afh.file_offset - nr_bytes);

--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -73,15 +73,23 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::BIGINT, Value::BIGINT(default_options.read_transfer_chunk_size));
 
 	config.AddExtensionOption("azure_read_buffer_size",
-	                          "Size of the read buffer.  It is recommended that this is evenly divisible by "
+	                          "Size of the read buffer. It is recommended that this is evenly divisible by "
 	                          "azure_read_transfer_chunk_size.",
 	                          LogicalType::UBIGINT, Value::UBIGINT(default_options.read_buffer_size));
 
-	config.AddExtensionOption("azure_write_staged_blocks_max",
-	                          "Maximum number of staged (uncommitted) blocks before an automatic mid-write commit. "
-	                          "Azure limits blobs to 100,000 total blocks; this safety valve prevents hitting that "
-	                          "limit by committing staged blocks early. Default: 10000.",
-	                          LogicalType::UBIGINT, Value::UBIGINT(default_options.write_staged_blocks_max));
+	config.AddExtensionOption("azure_write_block_size",
+	                          "Size in bytes of each block for Blob/DFS writes. "
+	                          "0 restores the default (8 MiB). Max 4000 MiB (Azure per-request limit). "
+	                          "Azure hard-limits a blob to 50,000 blocks; increase this to write files "
+	                          "larger than 50,000 × azure_write_block_size bytes.",
+	                          LogicalType::UBIGINT, Value::UBIGINT(default_options.write_block_size));
+
+	config.AddExtensionOption("azure_write_staged_blocks_per_commit",
+	                          "Number of blocks staged before an intermediate CommitBlockList. "
+	                          "0 (default) disables intermediate commits; the full block list is committed on close. "
+	                          "Non-zero values make partial writes visible sooner at the cost of extra commit RPCs. "
+	                          "Does not affect the 50,000-block blob limit; increase azure_write_block_size for that.",
+	                          LogicalType::UBIGINT, Value::UBIGINT(default_options.write_staged_blocks_per_commit));
 
 	auto *http_proxy = std::getenv("HTTP_PROXY");
 	Value default_http_value = http_proxy ? Value(http_proxy) : Value(nullptr);

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -273,9 +273,19 @@ AzureOptions AzureStorageFileSystem::ParseAzureOptions(optional_ptr<FileOpener> 
 		options.read_buffer_size = buffer_size_val.GetValue<idx_t>();
 	}
 
-	Value write_staged_blocks_max_val;
-	if (FileOpener::TryGetCurrentSetting(opener, "azure_write_staged_blocks_max", write_staged_blocks_max_val)) {
-		options.write_staged_blocks_max = write_staged_blocks_max_val.GetValue<idx_t>();
+	Value write_block_size_val;
+	if (FileOpener::TryGetCurrentSetting(opener, "azure_write_block_size", write_block_size_val)) {
+		auto size = write_block_size_val.GetValue<idx_t>();
+		if (size > AzureOptions::WRITE_BLOCK_SIZE_MAX) {
+			throw InvalidInputException("azure_write_block_size must be at most 4000 MiB");
+		}
+		options.write_block_size = (size > 0) ? size : AzureOptions::WRITE_BLOCK_SIZE_DEFAULT;
+	}
+
+	Value write_staged_blocks_per_commit_val;
+	if (FileOpener::TryGetCurrentSetting(opener, "azure_write_staged_blocks_per_commit",
+	                                     write_staged_blocks_per_commit_val)) {
+		options.write_staged_blocks_per_commit = write_staged_blocks_per_commit_val.GetValue<idx_t>();
 	}
 
 	return options;

--- a/src/include/azure_blob_filesystem.hpp
+++ b/src/include/azure_blob_filesystem.hpp
@@ -31,6 +31,7 @@ public:
 	                           const AzureOptions &options, Azure::Storage::Blobs::BlockBlobClient blob_client);
 	~AzureBlobStorageFileHandle() override = default;
 
+	void StageWriteBuffer();
 	void Sync();
 	void Close() override;
 
@@ -38,6 +39,8 @@ public:
 	Azure::Storage::Blobs::BlockBlobClient blob_client;
 	size_t committed_block_count = 0; // maintain position while open; only used if Sync() called before Close()
 	uint32_t staged_block_count = 0;
+	duckdb::unique_ptr<data_t[]> write_buffer;
+	idx_t write_buffer_offset = 0;
 };
 
 class AzureBlobStorageFileSystem : public AzureStorageFileSystem {

--- a/src/include/azure_dfs_filesystem.hpp
+++ b/src/include/azure_dfs_filesystem.hpp
@@ -31,11 +31,19 @@ public:
 	                          const AzureOptions &options, Azure::Storage::Files::DataLake::DataLakeFileClient client);
 	~AzureDfsStorageFileHandle() override = default;
 
+	void StageWriteBuffer();
 	void Sync(bool close = false);
 	void Close() override;
 
 public:
 	Azure::Storage::Files::DataLake::DataLakeFileClient file_client;
+	duckdb::unique_ptr<data_t[]> write_buffer;
+	idx_t write_buffer_offset = 0;
+	// Bytes sent to Append (staged on server, committed or not): always <= file_offset,
+	// with file_offset - staged_offset == write_buffer_offset.
+	idx_t staged_offset = 0;
+	uint32_t staged_block_count = 0;
+	uint32_t committed_block_count = 0;
 };
 
 class AzureDfsStorageFileSystem : public AzureStorageFileSystem {

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -15,10 +15,16 @@
 namespace duckdb {
 
 struct AzureOptions {
+	// 8 MiB - Base block size, copies rclone's default for concurrent transfers
+	// 4000 MiB - Azure doc'd max per Append/StageBlock
+	static const idx_t WRITE_BLOCK_SIZE_DEFAULT = (idx_t)8 * 1024 * 1024;
+	static const idx_t WRITE_BLOCK_SIZE_MAX = (idx_t)4000 * 1024 * 1024;
+
 	int32_t read_transfer_concurrency = 5;
 	int64_t read_transfer_chunk_size = (int64_t)8 * 1024 * 1024;
 	idx_t read_buffer_size = (idx_t)8 * 1024 * 1024;
-	idx_t write_staged_blocks_max = 10000;
+	idx_t write_block_size = WRITE_BLOCK_SIZE_DEFAULT;
+	idx_t write_staged_blocks_per_commit = 0;
 };
 
 class AzureContextState : public ClientContextState {

--- a/test/sql/azure_writes.test
+++ b/test/sql/azure_writes.test
@@ -89,3 +89,45 @@ FROM 'az://{AZ_TEMP_DIR}/compressed-1.csv.gz';
 ----
 1
 
+# -----------------------------------------------------------------------------
+# Write block-size and staged-commit params. 10 rows x 300-char payload -> ~3KB CSV,
+# using 1k blocks forces exercise of intermediate flush behaviors.
+#
+
+# staged_blocks_per_commit = 1: flush after every full block
+statement ok
+SET azure_write_block_size = 1024;
+
+statement ok
+SET azure_write_staged_blocks_per_commit = 1;
+
+statement ok
+COPY (SELECT repeat('x', 300) AS payload FROM range(10))
+TO 'az://{AZ_TEMP_DIR}/write-params-commit1.csv';
+
+query II
+SELECT count(*), sum(length(payload))
+FROM 'az://{AZ_TEMP_DIR}/write-params-commit1.csv';
+----
+10	3000
+
+# staged_blocks_per_commit = 2: flush every two blocks
+statement ok
+SET azure_write_staged_blocks_per_commit = 2;
+
+statement ok
+COPY (SELECT repeat('x', 300) AS payload FROM range(10))
+TO 'az://{AZ_TEMP_DIR}/write-params-commit2.csv';
+
+query II
+SELECT count(*), sum(length(payload))
+FROM 'az://{AZ_TEMP_DIR}/write-params-commit2.csv';
+----
+10	3000
+
+statement ok
+RESET azure_write_block_size;
+
+statement ok
+RESET azure_write_staged_blocks_per_commit;
+

--- a/test/sql/cloud/azure_writes.test
+++ b/test/sql/cloud/azure_writes.test
@@ -96,4 +96,46 @@ TO '{proto}://duckdblabs-write-testing/extension/azure/lineitem-partitioned' (
 ----
 is not empty
 
+# -----------------------------------------------------------------------------
+# Write block-size and staged-commit params. 10 rows x 300-char payload -> ~3KB CSV,
+# using 1k blocks forces exercise of intermediate flush behaviors.
+#
+
+# staged_blocks_per_commit = 1: flush after every full block
+statement ok
+SET azure_write_block_size = 1024;
+
+statement ok
+SET azure_write_staged_blocks_per_commit = 1;
+
+statement ok
+COPY (SELECT repeat('x', 300) AS payload FROM range(10))
+TO '{proto}://duckdblabs-write-testing/extension/azure/write-params-commit1.csv';
+
+query II
+SELECT count(*), sum(length(payload))
+FROM '{proto}://duckdblabs-write-testing/extension/azure/write-params-commit1.csv';
+----
+10	3000
+
+# staged_blocks_per_commit = 2: flush every two blocks
+statement ok
+SET azure_write_staged_blocks_per_commit = 2;
+
+statement ok
+COPY (SELECT repeat('x', 300) AS payload FROM range(10))
+TO '{proto}://duckdblabs-write-testing/extension/azure/write-params-commit2.csv';
+
+query II
+SELECT count(*), sum(length(payload))
+FROM '{proto}://duckdblabs-write-testing/extension/azure/write-params-commit2.csv';
+----
+10	3000
+
+statement ok
+RESET azure_write_block_size;
+
+statement ok
+RESET azure_write_staged_blocks_per_commit;
+
 endloop


### PR DESCRIPTION
Update buffer/stage/commit strategy during writes

Previous update (commit every 10k stage calls) address 1 Azure
limitation, but missed a second limitation. This fixes the full issue
of file size limitations mentioned in duckdb/duckdb-delta#299.

On top of earlier change to force Commit/Sync before hitting Azure blob
limit of 100k staged blocks, go a step further and introduce proper
write buffering with fixed-size blocks.

- introduces a local fixed size write buffer (same as S3 already does)
- by default allows files up to (50k * 8MB) ~= 390 GiB
- add buffer size option, allowing Azure's max 4000MiB buffers and
    190TiB files

Addresses (fully) duckdb/duckdb-delta#299