### PR TITLE
Expose azure_get_token() scalar to mint AAD bearer tokens

### DIFF
--- a/src/azure_extension.cpp
+++ b/src/azure_extension.cpp
@@ -2,6 +2,7 @@
 #include "azure_blob_filesystem.hpp"
 #include "azure_dfs_filesystem.hpp"
 #include "azure_secret.hpp"
+#include "azure_storage_account_client.hpp"
 
 namespace duckdb {
 
@@ -14,6 +15,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Load Secret functions
 	CreateAzureSecretFunctions::Register(loader);
+
+	// Register scalar functions
+	RegisterAzureGetTokenFunction(loader);
 
 	// Load extension config
 	auto &config = DBConfig::GetConfig(instance);

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -5,9 +5,13 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/function/scalar_function.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "http_logging_policy.hpp"
@@ -739,6 +743,55 @@ ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &p
 	auto account_url = "https://" + azure_parsed_url.storage_account_name + '.' + azure_parsed_url.endpoint;
 	auto dfs_options = ToDfsClientOptions(transport_options, opener);
 	return Azure::Storage::Files::DataLake::DataLakeServiceClient(account_url, dfs_options);
+}
+
+static const std::string AZURE_DEFAULT_TOKEN_SCOPE = "https://storage.azure.com/.default";
+
+static std::string FetchAzureBearerToken(const std::string &chain, const std::string &scope) {
+	Azure::Core::Http::Policies::TransportOptions transport_options;
+	auto credential = CreateChainedTokenCredential(chain, transport_options);
+
+	Azure::Core::Credentials::TokenRequestContext request_ctx;
+	request_ctx.Scopes = {scope};
+	try {
+		auto token = credential->GetToken(request_ctx, Azure::Core::Context());
+		return token.Token;
+	} catch (const std::exception &ex) {
+		throw InvalidConfigurationException(
+		    "azure_get_token failed for chain='%s': %s. "
+		    "If chain includes 'cli', ensure `az login` has been run.",
+		    chain, ex.what());
+	}
+}
+
+static void AzureGetTokenFunction0Args(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto token = FetchAzureBearerToken("default", AZURE_DEFAULT_TOKEN_SCOPE);
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::GetData<string_t>(result)[0] = StringVector::AddString(result, token);
+}
+
+static void AzureGetTokenFunction1Arg(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t chain_str) {
+		auto token = FetchAzureBearerToken(chain_str.GetString(), AZURE_DEFAULT_TOKEN_SCOPE);
+		return StringVector::AddString(result, token);
+	});
+}
+
+static void AzureGetTokenFunction2Args(DataChunk &args, ExpressionState &state, Vector &result) {
+	BinaryExecutor::Execute<string_t, string_t, string_t>(
+	    args.data[0], args.data[1], result, args.size(), [&](string_t chain_str, string_t scope_str) {
+		    auto token = FetchAzureBearerToken(chain_str.GetString(), scope_str.GetString());
+		    return StringVector::AddString(result, token);
+	    });
+}
+
+void RegisterAzureGetTokenFunction(ExtensionLoader &loader) {
+	ScalarFunctionSet set("azure_get_token");
+	set.AddFunction(ScalarFunction({}, LogicalType::VARCHAR, AzureGetTokenFunction0Args));
+	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, AzureGetTokenFunction1Arg));
+	set.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, AzureGetTokenFunction2Args));
+	loader.RegisterFunction(set);
 }
 
 } // namespace duckdb

--- a/src/azure_storage_account_client.cpp
+++ b/src/azure_storage_account_client.cpp
@@ -757,10 +757,9 @@ static std::string FetchAzureBearerToken(const std::string &chain, const std::st
 		auto token = credential->GetToken(request_ctx, Azure::Core::Context());
 		return token.Token;
 	} catch (const std::exception &ex) {
-		throw InvalidConfigurationException(
-		    "azure_get_token failed for chain='%s': %s. "
-		    "If chain includes 'cli', ensure `az login` has been run.",
-		    chain, ex.what());
+		throw InvalidConfigurationException("azure_get_token failed for chain='%s': %s. "
+		                                    "If chain includes 'cli', ensure `az login` has been run.",
+		                                    chain, ex.what());
 	}
 }
 

--- a/src/include/azure_storage_account_client.hpp
+++ b/src/include/azure_storage_account_client.hpp
@@ -11,6 +11,7 @@
 #include "azure_parsed_url.hpp"
 
 namespace duckdb {
+class ExtensionLoader;
 
 Azure::Storage::Blobs::BlobServiceClient ConnectToBlobStorageAccount(optional_ptr<FileOpener> opener,
                                                                      const std::string &path,
@@ -21,4 +22,6 @@ ConnectToDfsStorageAccount(optional_ptr<FileOpener> opener, const std::string &p
                            const AzureParsedUrl &azure_parsed_url);
 
 const SecretMatch LookupSecret(optional_ptr<FileOpener> opener, const std::string &path);
+
+void RegisterAzureGetTokenFunction(ExtensionLoader &loader);
 } // namespace duckdb


### PR DESCRIPTION
> **Disclosure:** this PR was authored with the assistance of an AI coding agent (Claude Code / Claude Opus 4.7). The code changes were generated by the agent under my direction, reviewed by me, and the commits include a `Co-Authored-By: Claude` trailer. The motivation, design choices, and security framing below reflect my requirements; the agent did the exploration, drafting, and CI iteration.

## Summary

Adds a single scalar function `azure_get_token([chain[, scope]])` that mints an Azure AAD bearer token from the same credential-chain providers duckdb-azure already understands (`cli`, `managed_identity`, `env`, `default`, `workload_identity`).

Three arities:

```sql
SELECT azure_get_token();                                                  -- chain='default', scope='https://storage.azure.com/.default'
SELECT azure_get_token('cli');                                             -- explicit chain
SELECT azure_get_token('cli', 'https://storage.azure.com/.default');       -- explicit scope
```

## Motivation

[duckdb/duckdb-iceberg#499](https://github.com/duckdb/duckdb-iceberg/issues/499) — attaching a OneLake REST iceberg catalog fails because the iceberg extension expects an OAuth2 client-credentials flow, while OneLake wants a plain AAD bearer token (the same one duckdb-azure already mints internally for storage reads).

[duckdb/duckdb-iceberg#612](https://github.com/duckdb/duckdb-iceberg/pull/612) was closed by @Tmonster because it pulled the Azure SDK into duckdb-iceberg. His suggestion was to keep Azure logic in duckdb-azure. This PR follows that direction without modifying duckdb-iceberg at all — duckdb-iceberg's `iceberg`-typed secret already accepts a static `token` field, so once duckdb-azure can produce one, ATTACH works untouched:

```sql
LOAD azure; LOAD iceberg;

SET VARIABLE onelake_token = (SELECT azure_get_token('cli'));
CREATE OR REPLACE SECRET onelake_cat (TYPE iceberg, TOKEN getvariable('onelake_token'));

ATTACH 'workspace/lakehouse.Lakehouse' AS onelake (
    TYPE ICEBERG,
    ENDPOINT 'https://onelake.table.fabric.microsoft.com/iceberg',
    SECRET onelake_cat
);
```

## Why expose a scalar, not a new secret type

A second `iceberg`-typed `credential_chain` secret in duckdb-azure was the obvious alternative but has two downsides:
1. It cross-registers a secret type that only exists when duckdb-iceberg is loaded — LOAD order matters, and surfaces a confusing "Secret type not found" error otherwise.
2. It's more code (new `CreateSecretFunction`, scope handling, redaction wiring) for what's essentially "call `GetToken` and stash the string".

A plain scalar function decouples duckdb-azure from duckdb-iceberg's secret-type registration entirely. The same primitive is also the natural hook for future auto-refresh.

## Security framing — this *reduces* token exposure compared to current practice

Without this function, the working pattern for OneLake users today is a launcher script that:

1. Shells out to `az account get-access-token --resource https://storage.azure.com/ -o tsv > %TEMP%\az_tok.txt`
2. Reads the file back, embeds the token plaintext in a `SET VARIABLE` statement inside an init SQL file (often under `C:\ProgramData\` so the path doesn't leak the username — which is *world-readable*)
3. Launches `duckdb -init <init.sql>`

That workflow lands the JWT on disk **twice** (the temp file and the init SQL file), and races a manual `DeleteFile` between the two. `azure_get_token()` keeps the token entirely in-memory: no disk write, no init-file plaintext, no temp-file cleanup race. The token surface is *narrower*, not wider — the function only succeeds when a chain provider is already authenticated (e.g. `az login`), and anyone with that prerequisite can already mint the same token by hand.

## Implementation

- New function `FetchAzureBearerToken(chain, scope)` in [src/azure_storage_account_client.cpp](src/azure_storage_account_client.cpp) — directly calls the existing `static CreateChainedTokenCredential` helper in the same translation unit, so no header churn for the static helper.
- Three thin scalar callbacks (0/1/2 args) using `UnaryExecutor` / `BinaryExecutor` to handle constant/null vectors.
- One-line addition in [src/azure_extension.cpp](src/azure_extension.cpp) registers the function set via `loader.RegisterFunction`.
- No CMake / vcpkg changes — `azure-identity-cpp` is already linked.
- No changes to duckdb-iceberg.

Total: ~60 net lines across 3 files.

## Out of scope

- **Auto-refresh.** Token validity is ~1h; when it expires the user re-runs `SET VARIABLE` + `CREATE OR REPLACE SECRET`. Real auto-refresh would require either duckdb-iceberg to call `azure_get_token()` on every catalog request / on 401, or a duckdb mechanism to make secret values be live expressions. Both are bigger conversations. This PR is the primitive that makes either approach possible later.
- **Storage-side auth for the actual parquet reads from OneLake** — already handled by the existing `TYPE azure` secret. Users attaching OneLake typically have two secrets: one `azure` (blob reads) and one `iceberg` (catalog).

## Test plan

- [x] CI green on format check + Linux amd64/arm64. Mac/Windows-static were green at last check; I'll repost results after the force-push CI run lands.
- [ ] Manual end-to-end against a real Fabric workspace:
  - `az login`
  - `SELECT length(azure_get_token('cli'))` returns a JWT
  - `ATTACH` against OneLake REST catalog succeeds, `SHOW TABLES` + `SELECT ... LIMIT 5` reads rows
- [ ] Negative test: `SELECT azure_get_token('cli')` without prior `az login` raises `InvalidConfigurationException` with the hint message.

Happy to add a sqllogictest verifying registration (`SELECT 1 FROM duckdb_functions() WHERE function_name = 'azure_get_token'`), mark the function `FunctionStability::VOLATILE`, and add a README section if you want any of those before merge.