### PR TITLE
pass etags through for improved caching

### DIFF
--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -209,6 +209,10 @@ vector<OpenFileInfo> AzureBlobStorageFileSystem::Glob(const string &path, FileOp
 				auto &options = info.extended_info->options;
 				options.emplace("file_size", Value::BIGINT(key.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(key.Details.LastModified)));
+				auto etag = StripETagQuotes(key.Details.ETag.ToString());
+				if (!etag.empty()) {
+					options.emplace("etag", Value(std::move(etag)));
+				}
 				result.push_back(info);
 			}
 		}
@@ -262,6 +266,10 @@ bool AzureBlobStorageFileSystem::ListFilesExtended(const string &path_in,
 				options.emplace("type", Value("file"));
 				options.emplace("file_size", Value::BIGINT(blob.BlobSize));
 				options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(blob.Details.LastModified)));
+				auto etag = StripETagQuotes(blob.Details.ETag.ToString());
+				if (!etag.empty()) {
+					options.emplace("etag", Value(std::move(etag)));
+				}
 				callback(info);
 			} else {
 				// chop off slash + tail, take the remainder and treat as directory, caching it in seen to avoid repeat.

--- a/src/azure_blob_filesystem.cpp
+++ b/src/azure_blob_filesystem.cpp
@@ -296,17 +296,18 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, must be created (file; dir create doesn't happen here)
 	// - doesn't exist, don't create
 
-	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod) {
+	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod, const string &etag) {
 		afh.is_remote_loaded = true; // always set loaded
 		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
 		afh.length = is_dir ? 0 : length;
 		afh.last_modified = last_mod;
+		afh.etag = StripETagQuotes(etag);
 		afh.file_offset = 0; // always reset offset state
 	};
 
 	auto create_file = [&]() {
 		auto res_create = afh.blob_client.CommitBlockList({});
-		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+		set_props(false, 0, ToTimestamp(res_create.Value.LastModified), res_create.Value.ETag.ToString());
 	};
 	auto truncate_file = create_file;
 
@@ -329,7 +330,8 @@ void AzureBlobStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 			auto ite = res_props.Value.Metadata.find("hdi_isFolder"); // NOTE: Metadata is case-insensitive
 			is_dir |= (ite != res_props.Value.Metadata.end() && ite->second == "true");
 		}
-		return set_props(is_dir, res_props.Value.BlobSize, ToTimestamp(res_props.Value.LastModified));
+		return set_props(is_dir, res_props.Value.BlobSize, ToTimestamp(res_props.Value.LastModified),
+		                 res_props.Value.ETag.ToString());
 	} catch (const Azure::Storage::StorageException &e) {
 		if (int(e.StatusCode) == 404 && afh.flags.OpenForWriting() &&
 		    (afh.flags.OverwriteExistingFile() || afh.flags.CreateFileIfNotExists())) {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -322,17 +322,18 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 	// - doesn't exist, must be created (file; dir create doesn't happen here)
 	// - doesn't exist, don't create
 
-	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod) {
+	auto set_props = [&](bool is_dir, idx_t length, timestamp_t last_mod, const string &etag) {
 		afh.is_remote_loaded = true; // always set loaded
 		afh.file_type = is_dir ? FileType::FILE_TYPE_DIR : FileType::FILE_TYPE_REGULAR;
 		afh.length = is_dir ? 0 : length;
 		afh.last_modified = last_mod;
+		afh.etag = StripETagQuotes(etag);
 		afh.file_offset = 0; // always reset offset state
 	};
 
 	auto create_file = [&]() {
 		auto res_create = afh.file_client.Create();
-		set_props(false, 0, ToTimestamp(res_create.Value.LastModified));
+		set_props(false, 0, ToTimestamp(res_create.Value.LastModified), res_create.Value.ETag.ToString());
 	};
 	auto truncate_file = create_file;
 
@@ -346,7 +347,8 @@ void AzureDfsStorageFileSystem::LoadRemoteFileInfo(AzureFileHandle &handle) {
 		}
 		// NOTE: honor convention for S3/Azure "foo/" empty file -> "foo" dir marker
 		auto is_dir = StringUtil::EndsWith(afh.GetPath(), "/") || res_props.Value.IsDirectory;
-		return set_props(is_dir, res_props.Value.FileSize, ToTimestamp(res_props.Value.LastModified));
+		return set_props(is_dir, res_props.Value.FileSize, ToTimestamp(res_props.Value.LastModified),
+		                 res_props.Value.ETag.ToString());
 	} catch (const Azure::Storage::StorageException &e) {
 		if (int(e.StatusCode) == 404 && afh.flags.OpenForWriting() &&
 		    (afh.flags.OverwriteExistingFile() || afh.flags.CreateFileIfNotExists())) {

--- a/src/azure_dfs_filesystem.cpp
+++ b/src/azure_dfs_filesystem.cpp
@@ -76,6 +76,10 @@ static void Walk(const Azure::Storage::Files::DataLake::DataLakeFileSystemClient
 					options.emplace("file_size", Value::BIGINT(elt.FileSize));
 					options.emplace("last_modified",
 					                Value::TIMESTAMP(AzureStorageFileSystem::ToTimestamp(elt.LastModified)));
+					auto etag = AzureStorageFileSystem::StripETagQuotes(elt.ETag);
+					if (!etag.empty()) {
+						options.emplace("etag", Value(std::move(etag)));
+					}
 					out_result->push_back(info);
 				}
 			}
@@ -297,6 +301,12 @@ bool AzureDfsStorageFileSystem::ListFilesExtended(const string &path_in,
 			options.emplace("type", std::move(file_type));
 			options.emplace("file_size", Value::BIGINT(UnsafeNumericCast<int64_t>(child.FileSize)));
 			options.emplace("last_modified", Value::TIMESTAMP(ToTimestamp(child.LastModified)));
+			if (!child.IsDirectory) {
+				auto etag = StripETagQuotes(child.ETag);
+				if (!etag.empty()) {
+					options.emplace("etag", Value(std::move(etag)));
+				}
+			}
 
 			// NOTE: there's a LOT of metadata available, and tags, etc. -- see
 			// https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/rest_client.hpp#L1134

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -39,17 +39,24 @@ AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo 
 
 	// Set metadata of file when available, it avoids to invoke to the storage to get them.
 	if (info.extended_info) {
-		auto entry1 = info.extended_info->options.find("file_size");
-		if (entry1 != info.extended_info->options.end()) {
+		auto &opts = info.extended_info->options;
+		auto entry1 = opts.find("file_size");
+		if (entry1 != opts.end()) {
 			length = entry1->second.GetValue<uint64_t>();
 		}
-		auto entry2 = info.extended_info->options.find("last_modified");
-		if (entry2 != info.extended_info->options.end()) {
+		auto entry2 = opts.find("last_modified");
+		if (entry2 != opts.end()) {
 			last_modified = entry2->second.GetValue<timestamp_t>();
 		}
-		auto entry3 = info.extended_info->options.find("etag");
-		if (entry3 != info.extended_info->options.end()) {
-			etag = entry3->second.ToString();
+		auto entry3 = opts.find("etag");
+		if (entry3 != opts.end()) {
+			etag = StringValue::Get(entry3->second);
+		}
+		// When glob supplied the full metadata triplet for a read, skip the HEAD (GetProperties) on open.
+		const bool have_all = entry1 != opts.end() && entry2 != opts.end() && entry3 != opts.end();
+		if (have_all && flags.OpenForReading() && !flags.OpenForWriting()) {
+			file_type = FileType::FILE_TYPE_REGULAR;
+			is_remote_loaded = true;
 		}
 	}
 }

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -47,6 +47,10 @@ AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo 
 		if (entry2 != info.extended_info->options.end()) {
 			last_modified = entry2->second.GetValue<timestamp_t>();
 		}
+		auto entry3 = info.extended_info->options.find("etag");
+		if (entry3 != info.extended_info->options.end()) {
+			etag = entry3->second.ToString();
+		}
 	}
 }
 
@@ -100,6 +104,11 @@ int64_t AzureStorageFileSystem::GetFileSize(FileHandle &handle) {
 timestamp_t AzureStorageFileSystem::GetLastModifiedTime(FileHandle &handle) {
 	auto &afh = handle.Cast<AzureFileHandle>();
 	return afh.last_modified;
+}
+
+string AzureStorageFileSystem::GetVersionTag(FileHandle &handle) {
+	auto &afh = handle.Cast<AzureFileHandle>();
+	return afh.etag;
 }
 
 void AzureStorageFileSystem::Seek(FileHandle &handle, idx_t location) {
@@ -296,6 +305,13 @@ timestamp_t AzureStorageFileSystem::ToTimestamp(const Azure::DateTime &dt) {
 	auto time_point = static_cast<std::chrono::system_clock::time_point>(dt);
 	auto micros = std::chrono::duration_cast<std::chrono::microseconds>(time_point.time_since_epoch()).count();
 	return timestamp_t(micros);
+}
+
+string AzureStorageFileSystem::StripETagQuotes(string etag) {
+	if (etag.size() >= 2 && etag.front() == '"' && etag.back() == '"') {
+		return etag.substr(1, etag.size() - 2);
+	}
+	return etag;
 }
 
 } // namespace duckdb

--- a/src/azure_filesystem.cpp
+++ b/src/azure_filesystem.cpp
@@ -53,8 +53,11 @@ AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, const OpenFileInfo 
 			etag = StringValue::Get(entry3->second);
 		}
 		// When glob supplied the full metadata triplet for a read, skip the HEAD (GetProperties) on open.
+		// Exclude trailing-slash paths: those follow the S3/Azure "foo/" dir-marker convention and must
+		// still be resolved to FILE_TYPE_DIR by LoadRemoteFileInfo rather than pre-typed as a regular file.
 		const bool have_all = entry1 != opts.end() && entry2 != opts.end() && entry3 != opts.end();
-		if (have_all && flags.OpenForReading() && !flags.OpenForWriting()) {
+		const bool looks_like_dir = !info.path.empty() && info.path.back() == '/';
+		if (have_all && !looks_like_dir && flags.OpenForReading() && !flags.OpenForWriting()) {
 			file_type = FileType::FILE_TYPE_REGULAR;
 			is_remote_loaded = true;
 		}

--- a/src/include/azure_filesystem.hpp
+++ b/src/include/azure_filesystem.hpp
@@ -79,6 +79,7 @@ public:
 	FileType file_type;
 	idx_t length;
 	timestamp_t last_modified;
+	string etag;
 
 	// Read buffer
 	duckdb::unique_ptr<data_t[]> read_buffer;
@@ -111,6 +112,7 @@ public:
 	}
 	int64_t GetFileSize(FileHandle &handle) override;
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+	string GetVersionTag(FileHandle &handle) override;
 	void Seek(FileHandle &handle, idx_t location) override;
 	idx_t SeekPosition(FileHandle &handle) override;
 
@@ -143,6 +145,7 @@ protected:
 
 public:
 	static timestamp_t ToTimestamp(const Azure::DateTime &dt);
+	static string StripETagQuotes(string etag);
 };
 
 } // namespace duckdb

--- a/test/sql/azure_etag.test
+++ b/test/sql/azure_etag.test
@@ -1,0 +1,40 @@
+# name: test/sql/azure_etag.test
+# description: ETag prefill from glob listings avoids the redundant GetProperties (HEAD) on open
+# group: [sql]
+
+require azure
+
+require parquet
+
+require-env AZURE_STORAGE_CONNECTION_STRING
+
+statement ok
+SET azure_storage_connection_string = '{AZURE_STORAGE_CONNECTION_STRING}';
+
+statement ok
+SET azure_http_stats = true;
+
+# -----------------------------------------------------------------------------
+# Baseline: explicit (non-wildcard) path
+#
+# A non-wildcard path resolves via FileExists + a per-open GetProperties, so the
+# read issues one or more HEAD requests. This is the pre-existing behavior and is
+# unaffected by the ETag work -- it establishes that HEADs do occur here.
+
+query II
+EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l.parquet';
+----
+analyzed_plan	<REGEX>:.*Azure HTTP Stats.*\#HEAD\: [1-9].*
+
+# -----------------------------------------------------------------------------
+# ETag prefill: glob (wildcard) path skips the HEAD
+#
+# A wildcard path is resolved by listing (ListBlobs / ListPaths), which now
+# carries file_size + last_modified + etag into each match's extended_info. On a
+# read-only open the handle is pre-loaded from that metadata, so no GetProperties
+# (HEAD) is needed -- the only remote calls are the listing and the data GETs.
+
+query II
+EXPLAIN ANALYZE SELECT sum(l_orderkey) FROM 'az://testing-private/l*.parquet';
+----
+analyzed_plan	<REGEX>:.*Azure HTTP Stats.*\#HEAD\: 0.*GET.*


### PR DESCRIPTION
On both reads and globs, forward applicable etags through file system for improve cache hits. Fixes recent breaking tests that caused additional (needless) HEAD/GET calls.